### PR TITLE
Fix connection retry frequency

### DIFF
--- a/lib/ably/realtime/connection/connection_manager.rb
+++ b/lib/ably/realtime/connection/connection_manager.rb
@@ -10,8 +10,8 @@ module Ably::Realtime
     class ConnectionManager
       # Configuration for automatic recovery of failed connection attempts
       CONNECT_RETRY_CONFIG = {
-        disconnected: { retry_every: 0.5, max_time_in_state: 10 },
-        suspended:    { retry_every: 5,   max_time_in_state: 60 }
+        disconnected: { retry_every: 15,  max_time_in_state: 120 },
+        suspended:    { retry_every: 120, max_time_in_state: Float::INFINITY }
       }.freeze
 
       # Time to wait following a connection state request before it's considered a failure

--- a/spec/acceptance/realtime/connection_failures_spec.rb
+++ b/spec/acceptance/realtime/connection_failures_spec.rb
@@ -127,7 +127,7 @@ describe Ably::Realtime::Connection, 'failures', :event_machine do
         end
 
         context 'when connection state is :suspended' do
-          it 'enters the failed state after multiple attempts' do
+          it 'enters the failed state after multiple attempts if the max_time_in_state is set' do
             connection.on(:connected) { raise 'Connection should not have reached :connected state' }
 
             connection.once(:suspended) do


### PR DESCRIPTION
As per documentation the retry frequency for disconnected need to be
every 15 seconds for 2 minutes and the retry frequency for suspended
needs to be every 2 minutes for as long as necessary.

First time I actually have a valid use case for `Float::INFINITY` :)