### PR TITLE
Ensure messages received once

### DIFF
--- a/lib/ably/realtime/connection/websocket_transport.rb
+++ b/lib/ably/realtime/connection/websocket_transport.rb
@@ -144,10 +144,13 @@ module Ably::Realtime
         driver.on("message") do |event|
           event_data = parse_event_data(event.data).freeze
           protocol_message = Ably::Models::ProtocolMessage.new(event_data, logger: logger)
-          logger.debug "WebsocketTransport: Prot msg recv <=: #{protocol_message.action} #{event_data}"
+          action_name = Ably::Models::ProtocolMessage::ACTION[event_data['action']] rescue event_data['action']
+          logger.debug "WebsocketTransport: Prot msg recv <=: #{action_name} - #{event_data}"
 
           if protocol_message.invalid?
-            logger.fatal "WebsocketTransport: Invalid Protocol Message received: #{event_data}\nNo action taken"
+            error = Ably::Exceptions::ProtocolError.new("Invalid Protocol Message received: #{event_data}\nMessage has been discarded", 400, 80013)
+            connection.trigger :error, error
+            logger.fatal "WebsocketTransport: #{error.message}"
           else
             __incoming_protocol_msgbus__.publish :protocol_message, protocol_message
           end


### PR DESCRIPTION
@paddybyers and @kouno, I handle protocol errors better in the library now, see https://github.com/ably/ably-ruby/issues/11.  @paddybyers, is my behaviour in line with yours if I receive a protocolmessage for an already received connectionSerial?