### PR TITLE
Support tokens in shorthand constructor instead of API key

### DIFF
--- a/lib/ably/rest/client.rb
+++ b/lib/ably/rest/client.rb
@@ -67,7 +67,7 @@ module Ably
 
       # Creates a {Ably::Rest::Client Rest Client} and configures the {Ably::Auth} object for the connection.
       #
-      # @param [Hash,String] options an options Hash used to configure the client and the authentication, or String with an API key
+      # @param [Hash,String] options an options Hash used to configure the client and the authentication, or String with an API key or Token ID
       # @option options (see Ably::Auth#authorise)
       # @option options [Boolean]                 :tls                 TLS is used by default, providing a value of false disables TLS.  Please note Basic Auth is disallowed without TLS as secrets cannot be transmitted over unsecured connections.
       # @option options [String]                  :api_key             API key comprising the key ID and key secret in a single string
@@ -96,7 +96,11 @@ module Ably
 
         options = options.clone
         if options.kind_of?(String)
-          options = { api_key: options }
+          options = if options.match(/^[\w]{2,}\.[\w]{2,}:[\w]{2,}$/)
+            { api_key:  options }
+          else
+            { token_id: options }
+          end
         end
 
         @tls           = options.delete(:tls) == false ? false : true

--- a/spec/shared/client_initializer_behaviour.rb
+++ b/spec/shared/client_initializer_behaviour.rb
@@ -113,6 +113,14 @@ shared_examples 'a client initializer' do
       end
     end
 
+    context 'with a string token key instead of options hash' do
+      let(:client_options) { 'app.kjhkasjhdsakdh127g7g1271' }
+
+      it 'sets the token_id' do
+        expect(subject.auth.token_id).to eql(client_options)
+      end
+    end
+
     context 'with token' do
       let(:client_options) { { token_id: 'token' } }
 


### PR DESCRIPTION
Fixes https://github.com/ably/ably-ruby/issues/5