### PR TITLE
History since attach

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,22 +1,27 @@
-# Ably Real-time & REST Client Library 0.7.5 Specification
+# Ably Realtime & REST Client Library 0.7.5 Specification
 
 ### Ably::Realtime::Channel#history
 _(see [spec/acceptance/realtime/channel_history_spec.rb](./spec/acceptance/realtime/channel_history_spec.rb))_
   * using JSON and MsgPack protocol
-    * [returns a SafeDeferrable that catches exceptions in callbacks and logs them](./spec/acceptance/realtime/channel_history_spec.rb#L20)
+    * [returns a SafeDeferrable that catches exceptions in callbacks and logs them](./spec/acceptance/realtime/channel_history_spec.rb#L21)
     * with a single client publishing and receiving
-      * [retrieves real-time history](./spec/acceptance/realtime/channel_history_spec.rb#L33)
+      * [retrieves realtime history](./spec/acceptance/realtime/channel_history_spec.rb#L34)
     * with two clients publishing messages on the same channel
-      * [retrieves real-time history on both channels](./spec/acceptance/realtime/channel_history_spec.rb#L45)
+      * [retrieves realtime history on both channels](./spec/acceptance/realtime/channel_history_spec.rb#L46)
     * with lots of messages published with a single client and channel
       * as one ProtocolMessage
-        * [retrieves history forwards with pagination through :limit option](./spec/acceptance/realtime/channel_history_spec.rb#L87)
-        * [retrieves history backwards with pagination through :limit option](./spec/acceptance/realtime/channel_history_spec.rb#L96)
+        * [retrieves history forwards with pagination through :limit option](./spec/acceptance/realtime/channel_history_spec.rb#L88)
+        * [retrieves history backwards with pagination through :limit option](./spec/acceptance/realtime/channel_history_spec.rb#L97)
       * in multiple ProtocolMessages
-        * [retrieves limited history forwards with pagination](./spec/acceptance/realtime/channel_history_spec.rb#L107)
-        * [retrieves limited history backwards with pagination](./spec/acceptance/realtime/channel_history_spec.rb#L118)
+        * [retrieves limited history forwards with pagination](./spec/acceptance/realtime/channel_history_spec.rb#L108)
+        * [retrieves limited history backwards with pagination](./spec/acceptance/realtime/channel_history_spec.rb#L119)
       * and REST history
-        * [return the same results with unique matching message IDs](./spec/acceptance/realtime/channel_history_spec.rb#L134)
+        * [return the same results with unique matching message IDs](./spec/acceptance/realtime/channel_history_spec.rb#L135)
+    * with option until_attach: true
+      * [retrieves all messages before channel was attached](./spec/acceptance/realtime/channel_history_spec.rb#L160)
+      * [raises an exception unless state is attached](./spec/acceptance/realtime/channel_history_spec.rb#L199)
+      * and two pages of messages
+        * [retrieves two pages of messages before channel was attached](./spec/acceptance/realtime/channel_history_spec.rb#L175)
 
 ### Ably::Realtime::Channel
 _(see [spec/acceptance/realtime/channel_spec.rb](./spec/acceptance/realtime/channel_spec.rb))_
@@ -398,6 +403,11 @@ _(see [spec/acceptance/realtime/presence_history_spec.rb](./spec/acceptance/real
   * using JSON and MsgPack protocol
     * [provides up to the moment presence history](./spec/acceptance/realtime/presence_history_spec.rb#L21)
     * [ensures REST presence history message IDs match ProtocolMessage wrapped message and connection IDs via Realtime](./spec/acceptance/realtime/presence_history_spec.rb#L41)
+    * with option until_attach: true
+      * [retrieves all presence messages before channel was attached](./spec/acceptance/realtime/presence_history_spec.rb#L60)
+      * [raises an exception unless state is attached](./spec/acceptance/realtime/presence_history_spec.rb#L92)
+      * and two pages of messages
+        * [retrieves two pages of messages before channel was attached](./spec/acceptance/realtime/presence_history_spec.rb#L73)
 
 ### Ably::Realtime::Presence
 _(see [spec/acceptance/realtime/presence_spec.rb](./spec/acceptance/realtime/presence_spec.rb))_
@@ -914,43 +924,43 @@ _(see [spec/acceptance/rest/presence_spec.rb](./spec/acceptance/rest/presence_sp
         * with :limit option
           * [returns a paged response limiting number of members per page](./spec/acceptance/rest/presence_spec.rb#L55)
       * #history
-        * [returns recent presence activity](./spec/acceptance/rest/presence_spec.rb#L72)
+        * [returns recent presence activity](./spec/acceptance/rest/presence_spec.rb#L67)
         * with options
           * direction: :forwards
-            * [returns recent presence activity forwards with most recent history last](./spec/acceptance/rest/presence_spec.rb#L88)
+            * [returns recent presence activity forwards with most recent history last](./spec/acceptance/rest/presence_spec.rb#L83)
           * direction: :backwards
-            * [returns recent presence activity backwards with most recent history first](./spec/acceptance/rest/presence_spec.rb#L103)
+            * [returns recent presence activity backwards with most recent history first](./spec/acceptance/rest/presence_spec.rb#L98)
     * #history
       * with time range options
         * :start
           * with milliseconds since epoch value
-            * [uses this value in the history request](./spec/acceptance/rest/presence_spec.rb#L148)
+            * [uses this value in the history request](./spec/acceptance/rest/presence_spec.rb#L143)
           * with Time object value
-            * [converts the value to milliseconds since epoch in the hisotry request](./spec/acceptance/rest/presence_spec.rb#L158)
+            * [converts the value to milliseconds since epoch in the hisotry request](./spec/acceptance/rest/presence_spec.rb#L153)
         * :end
           * with milliseconds since epoch value
-            * [uses this value in the history request](./spec/acceptance/rest/presence_spec.rb#L148)
+            * [uses this value in the history request](./spec/acceptance/rest/presence_spec.rb#L143)
           * with Time object value
-            * [converts the value to milliseconds since epoch in the hisotry request](./spec/acceptance/rest/presence_spec.rb#L158)
+            * [converts the value to milliseconds since epoch in the hisotry request](./spec/acceptance/rest/presence_spec.rb#L153)
     * decoding
       * with encoded fixture data
         * #history
-          * [decodes encoded and encryped presence fixture data automatically](./spec/acceptance/rest/presence_spec.rb#L178)
+          * [decodes encoded and encryped presence fixture data automatically](./spec/acceptance/rest/presence_spec.rb#L173)
         * #get
-          * [decodes encoded and encryped presence fixture data automatically](./spec/acceptance/rest/presence_spec.rb#L185)
+          * [decodes encoded and encryped presence fixture data automatically](./spec/acceptance/rest/presence_spec.rb#L180)
     * decoding permutations using mocked #history
       * valid decodeable content
         * #get
-          * [automaticaly decodes presence messages](./spec/acceptance/rest/presence_spec.rb#L241)
+          * [automaticaly decodes presence messages](./spec/acceptance/rest/presence_spec.rb#L236)
         * #history
-          * [automaticaly decodes presence messages](./spec/acceptance/rest/presence_spec.rb#L258)
+          * [automaticaly decodes presence messages](./spec/acceptance/rest/presence_spec.rb#L253)
       * invalid data
         * #get
-          * [returns the messages still encoded](./spec/acceptance/rest/presence_spec.rb#L289)
-          * [logs a cipher error](./spec/acceptance/rest/presence_spec.rb#L293)
+          * [returns the messages still encoded](./spec/acceptance/rest/presence_spec.rb#L284)
+          * [logs a cipher error](./spec/acceptance/rest/presence_spec.rb#L288)
         * #history
-          * [returns the messages still encoded](./spec/acceptance/rest/presence_spec.rb#L313)
-          * [logs a cipher error](./spec/acceptance/rest/presence_spec.rb#L317)
+          * [returns the messages still encoded](./spec/acceptance/rest/presence_spec.rb#L308)
+          * [logs a cipher error](./spec/acceptance/rest/presence_spec.rb#L312)
 
 ### Ably::Rest::Client#stats
 _(see [spec/acceptance/rest/stats_spec.rb](./spec/acceptance/rest/stats_spec.rb))_
@@ -1262,36 +1272,39 @@ _(see [spec/unit/models/message_spec.rb](./spec/unit/models/message_spec.rb))_
 
 ### Ably::Models::PaginatedResource
 _(see [spec/unit/models/paginated_resource_spec.rb](./spec/unit/models/paginated_resource_spec.rb))_
-  * [returns correct length from body](./spec/unit/models/paginated_resource_spec.rb#L30)
-  * [supports alias methods for length](./spec/unit/models/paginated_resource_spec.rb#L34)
-  * [is Enumerable](./spec/unit/models/paginated_resource_spec.rb#L39)
-  * [is iterable](./spec/unit/models/paginated_resource_spec.rb#L43)
-  * [provides [] accessor method](./spec/unit/models/paginated_resource_spec.rb#L61)
-  * [#first gets the first item in page](./spec/unit/models/paginated_resource_spec.rb#L67)
-  * [#last gets the last item in page](./spec/unit/models/paginated_resource_spec.rb#L71)
-  * #each
-    * [returns an enumerator](./spec/unit/models/paginated_resource_spec.rb#L48)
-    * [yields each item](./spec/unit/models/paginated_resource_spec.rb#L52)
+  * #items
+    * [returns correct length from body](./spec/unit/models/paginated_resource_spec.rb#L31)
+    * [is Enumerable](./spec/unit/models/paginated_resource_spec.rb#L35)
+    * [is iterable](./spec/unit/models/paginated_resource_spec.rb#L39)
+    * [provides [] accessor method](./spec/unit/models/paginated_resource_spec.rb#L57)
+    * [#first gets the first item in page](./spec/unit/models/paginated_resource_spec.rb#L63)
+    * [#last gets the last item in page](./spec/unit/models/paginated_resource_spec.rb#L67)
+    * #each
+      * [returns an enumerator](./spec/unit/models/paginated_resource_spec.rb#L44)
+      * [yields each item](./spec/unit/models/paginated_resource_spec.rb#L48)
   * with non paged http response
-    * [is the first page](./spec/unit/models/paginated_resource_spec.rb#L175)
-    * [is the last page](./spec/unit/models/paginated_resource_spec.rb#L179)
-    * [does not support pagination](./spec/unit/models/paginated_resource_spec.rb#L183)
-    * [raises an exception when accessing next page](./spec/unit/models/paginated_resource_spec.rb#L187)
-    * [raises an exception when accessing first page](./spec/unit/models/paginated_resource_spec.rb#L191)
+    * [is the first page](./spec/unit/models/paginated_resource_spec.rb#L172)
+    * [is the last page](./spec/unit/models/paginated_resource_spec.rb#L176)
+    * [does not have next page](./spec/unit/models/paginated_resource_spec.rb#L180)
+    * [does not support pagination](./spec/unit/models/paginated_resource_spec.rb#L184)
+    * [returns nil when accessing next page](./spec/unit/models/paginated_resource_spec.rb#L188)
+    * [returns nil when accessing first page](./spec/unit/models/paginated_resource_spec.rb#L192)
   * with paged http response
-    * [is the first page](./spec/unit/models/paginated_resource_spec.rb#L209)
-    * [is not the last page](./spec/unit/models/paginated_resource_spec.rb#L213)
-    * [supports pagination](./spec/unit/models/paginated_resource_spec.rb#L217)
+    * [is the first page](./spec/unit/models/paginated_resource_spec.rb#L210)
+    * [has next page](./spec/unit/models/paginated_resource_spec.rb#L214)
+    * [is not the last page](./spec/unit/models/paginated_resource_spec.rb#L218)
+    * [supports pagination](./spec/unit/models/paginated_resource_spec.rb#L222)
     * accessing next page
-      * [returns another PaginatedResource](./spec/unit/models/paginated_resource_spec.rb#L245)
-      * [retrieves the next page of results](./spec/unit/models/paginated_resource_spec.rb#L249)
-      * [is not the first page](./spec/unit/models/paginated_resource_spec.rb#L254)
-      * [is the last page](./spec/unit/models/paginated_resource_spec.rb#L258)
-      * [raises an exception if trying to access the last page when it is the last page](./spec/unit/models/paginated_resource_spec.rb#L262)
+      * [returns another PaginatedResource](./spec/unit/models/paginated_resource_spec.rb#L250)
+      * [retrieves the next page of results](./spec/unit/models/paginated_resource_spec.rb#L254)
+      * [is not the first page](./spec/unit/models/paginated_resource_spec.rb#L259)
+      * [does not have a next page](./spec/unit/models/paginated_resource_spec.rb#L263)
+      * [is the last page](./spec/unit/models/paginated_resource_spec.rb#L267)
+      * [returns nil when trying to access the last page when it is the last page](./spec/unit/models/paginated_resource_spec.rb#L271)
       * and then first page
-        * [returns a PaginatedResource](./spec/unit/models/paginated_resource_spec.rb#L273)
-        * [retrieves the first page of results](./spec/unit/models/paginated_resource_spec.rb#L277)
-        * [is the first page](./spec/unit/models/paginated_resource_spec.rb#L281)
+        * [returns a PaginatedResource](./spec/unit/models/paginated_resource_spec.rb#L282)
+        * [retrieves the first page of results](./spec/unit/models/paginated_resource_spec.rb#L286)
+        * [is the first page](./spec/unit/models/paginated_resource_spec.rb#L290)
 
 ### Ably::Models::PresenceMessage
 _(see [spec/unit/models/presence_message_spec.rb](./spec/unit/models/presence_message_spec.rb))_
@@ -2014,6 +2027,6 @@ _(see [spec/unit/util/pub_sub_spec.rb](./spec/unit/util/pub_sub_spec.rb))_
 
   ## Test summary
 
-  * Passing tests: 1003
+  * Passing tests: 1011
   * Pending tests: 7
   * Failing tests: 0

--- a/lib/ably/modules/async_wrapper.rb
+++ b/lib/ably/modules/async_wrapper.rb
@@ -47,8 +47,9 @@ module Ably::Modules
         operation_with_exception_handling = proc do
           begin
             yield
-          rescue StandardError => e
-            deferrable.fail e
+          rescue StandardError => err
+            logger.error "An exception in an AsyncWrapper block was caught. #{err.class}: #{err.message}\n#{err.backtrace.join("\n")}"
+            deferrable.fail err
           end
         end
 

--- a/lib/ably/realtime/channel.rb
+++ b/lib/ably/realtime/channel.rb
@@ -71,6 +71,11 @@ module Ably
       # @api private
       attr_reader :manager
 
+      # Serial number assigned to this channel when it was attached
+      # @return [Integer]
+      # @api private
+      attr_reader :attached_serial
+
       # Initialize a new Channel object
       #
       # @param  client [Ably::Rest::Client]
@@ -235,7 +240,7 @@ module Ably
       end
 
       private
-      attr_reader :queue, :attached_serial
+      attr_reader :queue
 
       def setup_event_handlers
         __incoming_msgbus__.subscribe(:message) do |message|

--- a/lib/ably/realtime/channel.rb
+++ b/lib/ably/realtime/channel.rb
@@ -179,25 +179,24 @@ module Ably
         @presence
       end
 
-      # Return the message history of the channel.
+      # Return the message history of the channel
       #
       # Once attached to a channel, you can retrieve messages published on the channel before the
-      # channel was attached with the option <tt>:end => :before_attach</tt>.  This is very useful for
-      # developers who wish to display both new realtime messages as well as historical messages with
+      # channel was attached with the option <tt>until_attach: true</tt>.  This is very useful for
+      # developers who wish to subscribe to new realtime messages yet also display historical messages with
       # the guarantee that no messages have been missed.
       #
       # @param (see Ably::Rest::Channel#history)
       # @option options (see Ably::Rest::Channel#history)
-      # @option options [Integer,Time,Symbol]   :end        Time or millisecond since epoch, or +:before_attach+ for all messages published before this channel has been attached.
+      # @option options [Boolean]  :until_attach  When true, request for history will be limited only to messages published before this channel was attached. Channel must be attached.
       #
       # @yield [Ably::Models::PaginatedResource<Ably::Models::Message>] First {Ably::Models::PaginatedResource page} of {Ably::Models::Message} objects accessible with {Ably::Models::PaginatedResource#items #items}.
       #
       # @return [Ably::Util::SafeDeferrable]
       def history(options = {}, &callback)
-        if options[:end] == :before_attach
-          raise ArgumentError, 'option :before_attach cannot be specified if the channel is not attached' unless attached?
+        if options.delete(:until_attach)
+          raise ArgumentError, 'option :until_attach cannot be specified if the channel is not attached' unless attached?
           options[:from_serial] = attached_serial
-          options.delete :end
         end
 
         async_wrap(callback) do

--- a/lib/ably/realtime/channel/channel_manager.rb
+++ b/lib/ably/realtime/channel/channel_manager.rb
@@ -40,6 +40,7 @@ module Ably::Realtime
         else
           channel.presence.manager.sync_not_expected
         end
+        channel.set_attached_serial attached_protocol_message.channel_serial
       end
 
       # An error has occurred on the channel

--- a/lib/ably/realtime/presence.rb
+++ b/lib/ably/realtime/presence.rb
@@ -265,14 +265,25 @@ module Ably::Realtime
 
     # Return the presence messages history for the channel
     #
+    # Once attached to a channel, you can retrieve presence message history on the channel before the
+    # channel was attached with the option <tt>until_attach: true</tt>.  This is very useful for
+    # developers who wish to capture new presence events as well as retrieve historical presence state with
+    # the guarantee that no presence history has been missed.
+    #
     # @param (see Ably::Rest::Presence#history)
     # @option options (see Ably::Rest::Presence#history)
+    # @option options [Boolean]  :until_attach  When true, request for history will be limited only to messages published before the associated channel was attached. The associated channel must be attached.
     #
     # @yield [Ably::Models::PaginatedResource<Ably::Models::PresenceMessage>] First {Ably::Models::PaginatedResource page} of {Ably::Models::PresenceMessage} objects accessible with {Ably::Models::PaginatedResource#items #items}.
     #
     # @return [Ably::Util::SafeDeferrable]
     #
     def history(options = {}, &callback)
+      if options.delete(:until_attach)
+        raise ArgumentError, 'option :until_attach cannot be specified if the channel is not attached' unless channel.attached?
+        options[:from_serial] = channel.attached_serial
+      end
+
       async_wrap(callback) do
         rest_presence.history(options.merge(async_blocking_operations: true))
       end

--- a/lib/ably/rest/channel.rb
+++ b/lib/ably/rest/channel.rb
@@ -20,7 +20,7 @@ module Ably
       # @param name [String] The name of the channel
       # @param channel_options [Hash] Channel options, currently reserved for Encryption options
       # @option channel_options [Boolean]  :encrypted       setting this to true for this channel will encrypt & decrypt all messages automatically
-      # @option channel_options [Hash]     :cipher_params   A hash of options to configure the encryption. *:key* is required, all other options are optional.  See {Ably::Util::Crypto#initialize} for a list of `cipher_params` options
+      # @option channel_options [Hash]     :cipher_params   A hash of options to configure the encryption. *:key* is required, all other options are optional.  See {Ably::Util::Crypto#initialize} for a list of +cipher_params+ options
       #
       def initialize(client, name, channel_options = {})
         ensure_utf_8 :name, name
@@ -52,14 +52,13 @@ module Ably
         [201, 204].include?(response.status)
       end
 
-      # Return the message history of the channel
+      # Return the message   of the channel
       #
       # @param [Hash] options the options for the message history request
       # @option options [Integer,Time] :start      Time or millisecond since epoch
       # @option options [Integer,Time] :end        Time or millisecond since epoch
-      # @option options [Symbol]       :direction  `:forwards` or `:backwards`
+      # @option options [Symbol]       :direction  +:forwards+ or +:backwards+
       # @option options [Integer]      :limit      Maximum number of messages to retrieve up to 10,000
-      # @option options [Symbol]       :by         `:message`, `:bundle` or `:hour`. Defaults to `:message`
       #
       # @return [Ably::Models::PaginatedResource<Ably::Models::Message>] First {Ably::Models::PaginatedResource page} of {Ably::Models::Message} objects accessible with {Ably::Models::PaginatedResource#items #items}.
       def history(options = {})

--- a/spec/unit/models/paginated_resource_spec.rb
+++ b/spec/unit/models/paginated_resource_spec.rb
@@ -5,7 +5,7 @@ describe Ably::Models::PaginatedResource do
   let(:paginated_resource_class) { Ably::Models::PaginatedResource }
   let(:headers) { Hash.new }
   let(:client) do
-    instance_double('Ably::Rest::Client', logger: true).tap do |client|
+    instance_double('Ably::Rest::Client', logger: Ably::Models::NilLogger.new).tap do |client|
       allow(client).to receive(:get).and_return(http_response)
     end
   end
@@ -87,7 +87,7 @@ describe Ably::Models::PaginatedResource do
       }
     end
     let(:paged_client) do
-      instance_double('Ably::Rest::Client', logger: true).tap do |client|
+      instance_double('Ably::Rest::Client', logger: Ably::Models::NilLogger.new).tap do |client|
         allow(client).to receive(:get).and_return(http_response_page2)
       end
     end

--- a/spec/unit/modules/async_wrapper_spec.rb
+++ b/spec/unit/modules/async_wrapper_spec.rb
@@ -16,7 +16,7 @@ describe Ably::Modules::AsyncWrapper, :api_private do
       end
 
       def logger
-        true
+        @logger ||= Ably::Models::NilLogger.new
       end
     end
   end


### PR DESCRIPTION
@kouno and @paddybyers following our chat, here is my proposal to support history requests on real-time channels that only give you messages published before the channel attached.

Please tell me what you think as we should probably add this or something like this to the other real-time client libraries.