### PR TITLE
Add coveralls.io coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ doc/*
 pkg
 .bundle
 bin
+coverage

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/ably/ably-ruby.png)](https://travis-ci.org/ably/ably-ruby)
 [![Gem Version](https://badge.fury.io/rb/ably.svg)](http://badge.fury.io/rb/ably)
+[![Coverage Status](https://coveralls.io/repos/ably/ably-ruby/badge.svg)](https://coveralls.io/r/ably/ably-ruby)
 
 A Ruby client library for [ably.io](https://ably.io), the real-time messaging service.
 

--- a/ably.gemspec
+++ b/ably.gemspec
@@ -33,4 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-retry'
   spec.add_development_dependency 'yard'
   spec.add_development_dependency 'webmock'
+
+  spec.add_development_dependency 'coveralls'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,9 @@ def console(message)
   puts "\033[31m[#{Time.now.strftime('%H:%M:%S.%L')}]\033[0m \033[33m#{message}\033[0m"
 end
 
+require 'coveralls'
+Coveralls.wear!
+
 require 'webmock/rspec'
 
 require 'ably'


### PR DESCRIPTION
@rjeczalik I have added coveralls support.  Once the build is done we should have coverage reporting.  Currently on the home page it says unknown coverage, see https://github.com/ably/ably-ruby/tree/coveralls.io

@kouno and @paddybyers seems sensible to add coveralls.io to all of our client libraries.  WDYT?