### PR TITLE
Test encoded presence fixture data for #get & #history

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -910,41 +910,47 @@ _(see [spec/acceptance/rest/presence_spec.rb](./spec/acceptance/rest/presence_sp
   * using JSON and MsgPack protocol
     * tested against presence fixture data set up in test app
       * #get
-        * [returns current members on the channel with their action set to :present](./spec/acceptance/rest/presence_spec.rb#L30)
+        * [returns current members on the channel with their action set to :present](./spec/acceptance/rest/presence_spec.rb#L41)
         * with :limit option
-          * [returns a paged response limiting number of members per page](./spec/acceptance/rest/presence_spec.rb#L44)
+          * [returns a paged response limiting number of members per page](./spec/acceptance/rest/presence_spec.rb#L55)
       * #history
-        * [returns recent presence activity](./spec/acceptance/rest/presence_spec.rb#L62)
+        * [returns recent presence activity](./spec/acceptance/rest/presence_spec.rb#L72)
         * with options
           * direction: :forwards
-            * [returns recent presence activity forwards with most recent history last](./spec/acceptance/rest/presence_spec.rb#L78)
+            * [returns recent presence activity forwards with most recent history last](./spec/acceptance/rest/presence_spec.rb#L88)
           * direction: :backwards
-            * [returns recent presence activity backwards with most recent history first](./spec/acceptance/rest/presence_spec.rb#L93)
+            * [returns recent presence activity backwards with most recent history first](./spec/acceptance/rest/presence_spec.rb#L103)
     * #history
       * with time range options
         * :start
           * with milliseconds since epoch value
-            * [uses this value in the history request](./spec/acceptance/rest/presence_spec.rb#L138)
+            * [uses this value in the history request](./spec/acceptance/rest/presence_spec.rb#L148)
           * with Time object value
-            * [converts the value to milliseconds since epoch in the hisotry request](./spec/acceptance/rest/presence_spec.rb#L148)
+            * [converts the value to milliseconds since epoch in the hisotry request](./spec/acceptance/rest/presence_spec.rb#L158)
         * :end
           * with milliseconds since epoch value
-            * [uses this value in the history request](./spec/acceptance/rest/presence_spec.rb#L138)
+            * [uses this value in the history request](./spec/acceptance/rest/presence_spec.rb#L148)
           * with Time object value
-            * [converts the value to milliseconds since epoch in the hisotry request](./spec/acceptance/rest/presence_spec.rb#L148)
+            * [converts the value to milliseconds since epoch in the hisotry request](./spec/acceptance/rest/presence_spec.rb#L158)
     * decoding
+      * with encoded fixture data
+        * #history
+          * [decodes encoded and encryped presence fixture data automatically](./spec/acceptance/rest/presence_spec.rb#L178)
+        * #get
+          * [decodes encoded and encryped presence fixture data automatically](./spec/acceptance/rest/presence_spec.rb#L185)
+    * decoding permutations using mocked #history
       * valid decodeable content
         * #get
-          * [automaticaly decodes presence messages](./spec/acceptance/rest/presence_spec.rb#L206)
+          * [automaticaly decodes presence messages](./spec/acceptance/rest/presence_spec.rb#L241)
         * #history
-          * [automaticaly decodes presence messages](./spec/acceptance/rest/presence_spec.rb#L223)
+          * [automaticaly decodes presence messages](./spec/acceptance/rest/presence_spec.rb#L258)
       * invalid data
         * #get
-          * [returns the messages still encoded](./spec/acceptance/rest/presence_spec.rb#L254)
-          * [logs a cipher error](./spec/acceptance/rest/presence_spec.rb#L258)
+          * [returns the messages still encoded](./spec/acceptance/rest/presence_spec.rb#L289)
+          * [logs a cipher error](./spec/acceptance/rest/presence_spec.rb#L293)
         * #history
-          * [returns the messages still encoded](./spec/acceptance/rest/presence_spec.rb#L278)
-          * [logs a cipher error](./spec/acceptance/rest/presence_spec.rb#L282)
+          * [returns the messages still encoded](./spec/acceptance/rest/presence_spec.rb#L313)
+          * [logs a cipher error](./spec/acceptance/rest/presence_spec.rb#L317)
 
 ### Ably::Rest::Client#stats
 _(see [spec/acceptance/rest/stats_spec.rb](./spec/acceptance/rest/stats_spec.rb))_
@@ -2008,6 +2014,6 @@ _(see [spec/unit/util/pub_sub_spec.rb](./spec/unit/util/pub_sub_spec.rb))_
 
   ## Test summary
 
-  * Passing tests: 1001
+  * Passing tests: 1003
   * Pending tests: 7
   * Failing tests: 0

--- a/spec/acceptance/rest/presence_spec.rb
+++ b/spec/acceptance/rest/presence_spec.rb
@@ -20,22 +20,22 @@ describe Ably::Rest::Presence do
 
     # Encrypted fixtures need encryption details or an error will be raised
     let(:cipher_details)   { TestApp::APP_SPEC_CIPHER }
-    let(:algorithm)        { cipher_details.fetch(:algorithm).upcase }
-    let(:mode)             { cipher_details.fetch(:mode).upcase }
-    let(:key_length)       { cipher_details.fetch(:keylength) }
-    let(:secret_key)       { Base64.decode64(cipher_details.fetch(:key)) }
-    let(:iv)               { Base64.decode64(cipher_details.fetch(:iv)) }
+    let(:algorithm)        { cipher_details.fetch('algorithm').upcase }
+    let(:mode)             { cipher_details.fetch('mode').upcase }
+    let(:key_length)       { cipher_details.fetch('keylength') }
+    let(:secret_key)       { Base64.decode64(cipher_details.fetch('key')) }
+    let(:iv)               { Base64.decode64(cipher_details.fetch('iv')) }
 
     let(:cipher_options)   { { key: secret_key, algorithm: algorithm, mode: mode, key_length: key_length, iv: iv } }
     let(:fixtures_channel) { client.channel('persisted:presence_fixtures', encrypted: true, cipher_params: cipher_options, iv: iv) }
 
     context 'tested against presence fixture data set up in test app' do
-      describe '#get' do
-        before(:context) do
-          # When this test is run as a part of a test suite, the presence data injected in the test app may have expired
-          reload_test_app
-        end
+      before(:context) do
+        # When this test is run as a part of a test suite, the presence data injected in the test app may have expired
+        reload_test_app
+      end
 
+      describe '#get' do
         let(:presence) { fixtures_channel.presence.get }
 
         it 'returns current members on the channel with their action set to :present' do
@@ -62,11 +62,6 @@ describe Ably::Rest::Presence do
       end
 
       describe '#history' do
-        before(:context) do
-          # When this test is run as a part of a test suite, the presence data injected in the test app may have expired
-          reload_test_app
-        end
-
         let(:presence_history) { fixtures_channel.presence.history }
 
         it 'returns recent presence activity' do

--- a/spec/acceptance/rest/presence_spec.rb
+++ b/spec/acceptance/rest/presence_spec.rb
@@ -16,6 +16,18 @@ describe Ably::Rest::Presence do
         IdiomaticRubyWrapper(fixture, stop_at: [:data])
       end
     end
+    let(:non_encoded_fixtures) { fixtures.reject { |fixture| fixture['encoding'] } }
+
+    # Encrypted fixtures need encryption details or an error will be raised
+    let(:cipher_details)   { TestApp::APP_SPEC_CIPHER }
+    let(:algorithm)        { cipher_details.fetch(:algorithm).upcase }
+    let(:mode)             { cipher_details.fetch(:mode).upcase }
+    let(:key_length)       { cipher_details.fetch(:keylength) }
+    let(:secret_key)       { Base64.decode64(cipher_details.fetch(:key)) }
+    let(:iv)               { Base64.decode64(cipher_details.fetch(:iv)) }
+
+    let(:cipher_options)   { { key: secret_key, algorithm: algorithm, mode: mode, key_length: key_length, iv: iv } }
+    let(:fixtures_channel) { client.channel('persisted:presence_fixtures', encrypted: true, cipher_params: cipher_options, iv: iv) }
 
     context 'tested against presence fixture data set up in test app' do
       describe '#get' do
@@ -24,13 +36,12 @@ describe Ably::Rest::Presence do
           reload_test_app
         end
 
-        let(:channel) { client.channel('persisted:presence_fixtures') }
-        let(:presence) { channel.presence.get }
+        let(:presence) { fixtures_channel.presence.get }
 
         it 'returns current members on the channel with their action set to :present' do
-          expect(presence.size).to eql(4)
+          expect(presence.size).to eql(fixtures.count)
 
-          fixtures.each do |fixture|
+          non_encoded_fixtures.each do |fixture|
             presence_message = presence.find { |client| client.client_id == fixture[:client_id] }
             expect(presence_message.data).to eq(fixture[:data])
             expect(presence_message.action).to eq(:present)
@@ -38,13 +49,13 @@ describe Ably::Rest::Presence do
         end
 
         context 'with :limit option' do
-          let(:page_size) { 2 }
-          let(:presence)  { channel.presence.get(limit: page_size) }
+          let(:page_size) { 3 }
+          let(:presence)  { fixtures_channel.presence.get(limit: page_size) }
 
           it 'returns a paged response limiting number of members per page' do
-            expect(presence.size).to eql(2)
+            expect(presence.size).to eql(page_size)
             next_page = presence.next_page
-            expect(next_page.size).to eql(2)
+            expect(next_page.size).to eql(page_size)
             expect(next_page).to be_last_page
           end
         end
@@ -56,28 +67,27 @@ describe Ably::Rest::Presence do
           reload_test_app
         end
 
-        let(:channel) { client.channel('persisted:presence_fixtures') }
-        let(:presence_history) { channel.presence.history }
+        let(:presence_history) { fixtures_channel.presence.history }
 
         it 'returns recent presence activity' do
-          expect(presence_history.size).to eql(4)
+          expect(presence_history.size).to eql(fixtures.count)
 
-          fixtures.each do |fixture|
+          non_encoded_fixtures.each do |fixture|
             presence_message = presence_history.find { |client| client.client_id == fixture['clientId'] }
             expect(presence_message.data).to eq(fixture[:data])
           end
         end
 
         context 'with options' do
-          let(:page_size) { 2 }
+          let(:page_size) { 3 }
 
           context 'direction: :forwards' do
-            let(:presence_history) { channel.presence.history(direction: :forwards) }
-            let(:paged_history_forward) { channel.presence.history(limit: page_size, direction: :forwards) }
+            let(:presence_history) { fixtures_channel.presence.history(direction: :forwards) }
+            let(:paged_history_forward) { fixtures_channel.presence.history(limit: page_size, direction: :forwards) }
 
             it 'returns recent presence activity forwards with most recent history last' do
               expect(paged_history_forward).to be_a(Ably::Models::PaginatedResource)
-              expect(paged_history_forward.size).to eql(2)
+              expect(paged_history_forward.size).to eql(page_size)
 
               next_page = paged_history_forward.next_page
 
@@ -87,12 +97,12 @@ describe Ably::Rest::Presence do
           end
 
           context 'direction: :backwards' do
-            let(:presence_history) { channel.presence.history(direction: :backwards) }
-            let(:paged_history_backward) { channel.presence.history(limit: page_size, direction: :backwards) }
+            let(:presence_history) { fixtures_channel.presence.history(direction: :backwards) }
+            let(:paged_history_backward) { fixtures_channel.presence.history(limit: page_size, direction: :backwards) }
 
             it 'returns recent presence activity backwards with most recent history first' do
               expect(paged_history_backward).to be_a(Ably::Models::PaginatedResource)
-              expect(paged_history_backward.size).to eql(2)
+              expect(paged_history_backward.size).to eql(page_size)
 
               next_page = paged_history_backward.next_page
 
@@ -154,7 +164,32 @@ describe Ably::Rest::Presence do
       end
     end
 
-    describe 'decoding', :webmock do
+    describe 'decoding' do
+      context 'with encoded fixture data' do
+        let(:decoded_client_id) { 'client_decoded' }
+        let(:encoded_client_id) { 'client_encoded' }
+
+        def message(client_id, messages)
+          messages.find { |message| message.client_id == client_id }
+        end
+
+        describe '#history' do
+          let(:history) { fixtures_channel.presence.history }
+          it 'decodes encoded and encryped presence fixture data automatically' do
+            expect(message(decoded_client_id, history).data).to eql(message(encoded_client_id, history).data)
+          end
+        end
+
+        describe '#get' do
+          let(:present) { fixtures_channel.presence.get }
+          it 'decodes encoded and encryped presence fixture data automatically' do
+            expect(message(decoded_client_id, present).data).to eql(message(encoded_client_id, present).data)
+          end
+        end
+      end
+    end
+
+    describe 'decoding permutations using mocked #history', :webmock do
       let(:user) { 'appid.keyuid' }
       let(:secret) { random_str(8) }
       let(:endpoint) do

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -1,43 +1,15 @@
 require 'singleton'
 
 class TestApp
-  APP_SPEC = {
-    'keys' => [
-      {},
-      {
-        'capability' => '{ "cansubscribe:*":["subscribe"], "canpublish:*":["publish"], "canpublish:andpresence":["presence","publish"] }'
-      }
-    ],
-    'namespaces' => [
-      { 'id' => 'persisted', 'persisted' => true }
-    ],
-    'channels' => [
-      {
-        'name' => 'persisted:presence_fixtures',
-        'presence' => [
-          { 'clientId' => 'client_bool',    'data' => 'true' },
-          { 'clientId' => 'client_int',     'data' => '24' },
-          { 'clientId' => 'client_string',  'data' => 'This is a string clientData payload' },
-          { 'clientId' => 'client_json',    'data' => '{ "test" => \'This is a JSONObject clientData payload\'}' },
-          { 'clientId' => 'client_decoded', 'data' => '{"example":{"json":"Object"}}', 'encoding' => 'json/utf-8' },
-          {
-            'clientId' => 'client_encoded',
-            'data' => 'HO4cYSP8LybPYBPZPHQOtuD53yrD3YV3NBoTEYBh4U0N1QXHbtkfsDfTspKeLQFt',
-            'encoding' => 'json/utf-8/cipher+aes-128-cbc/base64'
-          }
-        ]
-      }
-    ]
-  }
+  TEST_RESOURCES_PATH = File.expand_path('../../../lib/submodules/ably-common/test-resources', __FILE__)
 
-  # Cipher details used for client_encoded presence data
-  APP_SPEC_CIPHER = {
-    algorithm: 'aes',
-    mode: 'cbc',
-    keylength: 128,
-    key: 'WUP6u0K7MXI5Zeo0VppPwg==',
-    iv: 'HO4cYSP8LybPYBPZPHQOtg==',
-  }
+  # App configuration for test app
+  # See https://github.com/ably/ably-common/blob/master/test-resources/test-app-setup.json
+  APP_SPEC = JSON.parse(File.read(File.join(TEST_RESOURCES_PATH, 'test-app-setup.json')))['post_apps']
+
+  # Cipher details used for client_encoded presence data in test app
+  # See https://github.com/ably/ably-common/blob/master/test-resources/test-app-setup.json
+  APP_SPEC_CIPHER = JSON.parse(File.read(File.join(TEST_RESOURCES_PATH, 'test-app-setup.json')))['cipher']
 
   # If an app has already been created and we need a new app, create a new test app
   # This is sometimes needed when a test needs to be isolated from any other tests

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -23,7 +23,7 @@ class TestApp
           {
             'clientId' => 'client_encoded',
             'data' => 'HO4cYSP8LybPYBPZPHQOtuD53yrD3YV3NBoTEYBh4U0N1QXHbtkfsDfTspKeLQFt',
-            'encoding': 'json/utf-8/cipher+aes-128-cbc/base64'
+            'encoding' => 'json/utf-8/cipher+aes-128-cbc/base64'
           }
         ]
       }

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -18,10 +18,25 @@ class TestApp
           { 'clientId' => 'client_bool',    'data' => 'true' },
           { 'clientId' => 'client_int',     'data' => '24' },
           { 'clientId' => 'client_string',  'data' => 'This is a string clientData payload' },
-          { 'clientId' => 'client_json',    'data' => '{ "test" => \'This is a JSONObject clientData payload\'}' }
+          { 'clientId' => 'client_json',    'data' => '{ "test" => \'This is a JSONObject clientData payload\'}' },
+          { 'clientId' => 'client_decoded', 'data' => '{"example":{"json":"Object"}}', 'encoding' => 'json/utf-8' },
+          {
+            'clientId' => 'client_encoded',
+            'data' => 'HO4cYSP8LybPYBPZPHQOtuD53yrD3YV3NBoTEYBh4U0N1QXHbtkfsDfTspKeLQFt',
+            'encoding': 'json/utf-8/cipher+aes-128-cbc/base64'
+          }
         ]
       }
     ]
+  }
+
+  # Cipher details used for client_encoded presence data
+  APP_SPEC_CIPHER = {
+    algorithm: 'aes',
+    mode: 'cbc',
+    keylength: 128,
+    key: 'WUP6u0K7MXI5Zeo0VppPwg==',
+    iv: 'HO4cYSP8LybPYBPZPHQOtg==',
   }
 
   # If an app has already been created and we need a new app, create a new test app


### PR DESCRIPTION
@kouno following our discussion, I added new encoded & encrypted fixture presence data that is sent to Ably when setting up the Test App.  I believe we only really need one Presence specific test for decoding of data via REST as Messages already have extensive test coverage and this simply ensures that we have an acceptance test communicating with the Ably service without any stubbing.

This includes:

* Set up encoded & encrypted presence data when setting up a test app
* Added tests for presence#get and presence#history that ensure that presence messages retrieved are decoded as expected.
* Updated the API Spec

Would you like to show this to Matus?