### PR TITLE
Reject invalid payload type

### DIFF
--- a/lib/ably/exceptions.rb
+++ b/lib/ably/exceptions.rb
@@ -74,5 +74,8 @@ module Ably
 
     # The message could not be delivered to the server
     class MessageDeliveryError < BaseAblyException; end
+
+    # The data payload type is not supported
+    class UnsupportedDataTypeError < BaseAblyException; end
   end
 end

--- a/lib/ably/modules/conversions.rb
+++ b/lib/ably/modules/conversions.rb
@@ -96,5 +96,20 @@ module Ably::Modules
     rescue Encoding::UndefinedConversionError, Encoding::InvalidByteSequenceError => e
       raise ArgumentError, "#{field_name} could not be converted to UTF-8: #{e.message}"
     end
+
+    # Ensures that the payload is a type supported by all Ably client libraries.
+    # Ably guarantees interoperability between client libraries and subsequently
+    # client libraries must reject unsupported types
+    #
+    # @return <void>
+    #
+    def ensure_supported_payload(payload)
+      return if payload.kind_of?(String) ||
+        payload.kind_of?(Hash) ||
+        payload.kind_of?(Array) ||
+        payload.nil?
+
+      raise Ably::Exceptions::UnsupportedDataTypeError.new('Invalid data payload', 400, 40011)
+    end
   end
 end

--- a/lib/ably/realtime/channel.rb
+++ b/lib/ably/realtime/channel.rb
@@ -122,6 +122,7 @@ module Ably
       #
       def publish(name, data, &success_block)
         ensure_utf_8 :name, name
+        ensure_supported_payload data
 
         create_message(name, data).tap do |message|
           message.callback(&success_block) if block_given?

--- a/lib/ably/rest/channel.rb
+++ b/lib/ably/rest/channel.rb
@@ -37,6 +37,7 @@ module Ably
       # @return [Boolean] true if the message was published, otherwise false
       def publish(name, data)
         ensure_utf_8 :name, name
+        ensure_supported_payload data
 
         payload = {
           name: name,

--- a/spec/acceptance/realtime/message_spec.rb
+++ b/spec/acceptance/realtime/message_spec.rb
@@ -32,6 +32,83 @@ describe 'Ably::Realtime::Channel Message', :event_machine do
       end
     end
 
+    context 'with supported data payload content type' do
+      def publish_and_check_data(data)
+        channel.attach
+        channel.publish 'event', data
+        channel.subscribe do |message|
+          expect(message.data).to eql(data)
+          stop_reactor
+        end
+      end
+
+      context 'JSON Object (Hash)' do
+        let(:data) { { 'Hash' => 'true' } }
+
+        it 'is encoded and decoded to the same hash' do
+          publish_and_check_data data
+        end
+      end
+
+      context 'JSON Array' do
+        let(:data) { [ nil, true, false, 55, 'string', { 'Hash' => true }, ['array'] ] }
+
+        it 'is encoded and decoded to the same Array' do
+          publish_and_check_data data
+        end
+      end
+
+      context 'String' do
+        let(:data) { random_str }
+
+        it 'is encoded and decoded to the same Array' do
+          publish_and_check_data data
+        end
+      end
+
+      context 'Binary' do
+        let(:data) { Base64.encode64(random_str) }
+
+        it 'is encoded and decoded to the same Array' do
+          publish_and_check_data data
+        end
+      end
+    end
+
+    context 'with unsupported data payload content type' do
+      context 'Integer' do
+        let(:data) { 1 }
+
+        it 'is raises an UnsupportedDataTypeError 40011 exception' do
+          expect { channel.publish 'event', data }.to raise_error(Ably::Exceptions::UnsupportedDataTypeError)
+        end
+      end
+
+      context 'Float' do
+        let(:data) { 1.1 }
+
+        it 'is raises an UnsupportedDataTypeError 40011 exception' do
+          expect { channel.publish 'event', data }.to raise_error(Ably::Exceptions::UnsupportedDataTypeError)
+        end
+      end
+
+      context 'Boolean' do
+        let(:data) { true }
+
+        it 'is raises an UnsupportedDataTypeError 40011 exception' do
+          expect { channel.publish 'event', data }.to raise_error(Ably::Exceptions::UnsupportedDataTypeError)
+        end
+      end
+
+      context 'False' do
+        let(:data) { false }
+
+        it 'is raises an UnsupportedDataTypeError 40011 exception' do
+          expect { channel.publish 'event', data }.to raise_error(Ably::Exceptions::UnsupportedDataTypeError)
+        end
+      end
+    end
+
     context 'with ASCII_8BIT message name' do
       let(:message_name) { random_str.encode(Encoding::ASCII_8BIT) }
       it 'is converted into UTF_8' do

--- a/spec/acceptance/rest/presence_spec.rb
+++ b/spec/acceptance/rest/presence_spec.rb
@@ -5,7 +5,7 @@ describe Ably::Rest::Presence do
   include Ably::Modules::Conversions
 
   vary_by_protocol do
-    let(:default_options) { { key: api_key, environment: environment, protocol: protocol } }
+    let(:default_options) { { key: api_key, environment: environment, protocol: protocol, log_level: :debug } }
     let(:client_options) { default_options }
     let(:client) do
       Ably::Rest::Client.new(client_options)
@@ -54,6 +54,7 @@ describe Ably::Rest::Presence do
 
           it 'returns a paged response limiting number of members per page' do
             expect(presence_page.items.size).to eql(page_size)
+            expect(presence_page).to be_first
             next_page = presence_page.next
             expect(next_page.items.size).to eql(page_size)
             expect(next_page).to be_last


### PR DESCRIPTION
@SimonWoolf & @paddybyers following our discussion today, commit c3309fd ensures that non supported data payload types raise an exception immediately.

I had to add a new error code too, see https://github.com/ably/ably-common/commit/5ea9a3334309f9e108f1bed2ffff09c70043a043

Can you tell me if you are happy with this?  If so, I will amend our [feature documentation](http://docs.ably.io/client-lib-development-guide/features/) and communicate this out to everyone.

FYI @kouno