### PR TITLE
Ensure files are required in a consistent order

### DIFF
--- a/lib/ably.rb
+++ b/lib/ably.rb
@@ -1,5 +1,5 @@
 %w(modules util).each do |namespace|
-  Dir.glob(File.expand_path("ably/#{namespace}/*.rb", File.dirname(__FILE__))).each do |file|
+  Dir.glob(File.expand_path("ably/#{namespace}/*.rb", File.dirname(__FILE__))).sort.each do |file|
     require file
   end
 end


### PR DESCRIPTION
The order files are returned by Dir.glob is [unspecified and OS-dependent](http://ruby-doc.org/core-2.2.2/Dir.html#method-c-glob), which was causing odd behaviour on Linux. Add a sort to ensure files are required in a consistent order across all OSes