### PR TITLE
Separate token params for auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ token_details = client.auth.request_token
 token_details.token # => "xVLyHw.CLchevH3hF....MDh9ZC_Q"
 client = Ably::Rest.new(token: token_details.token)
 
-token = client.auth.create_token_request
+token = client.auth.create_token_request(token_params: { ttl: 3600 })
 # => {"id"=>...,
 #     "clientId"=>nil,
 #     "ttl"=>3600,

--- a/lib/ably/auth.rb
+++ b/lib/ably/auth.rb
@@ -160,8 +160,8 @@ module Ably
 
       token_request = if auth_callback = auth_options.delete(:auth_callback)
         auth_callback.call(token_params)
-      elsif auth_url = token_params.delete(:auth_url)
-        token_request_from_auth_url(auth_url, token_params)
+      elsif auth_url = auth_options.delete(:auth_url)
+        token_request_from_auth_url(auth_url, auth_options)
       else
         create_token_request(auth_options, token_params)
       end
@@ -451,10 +451,10 @@ module Ably
     # Retrieve a token request from a specified URL, expects a JSON response
     #
     # @return [Hash]
-    def token_request_from_auth_url(auth_url, options = {})
+    def token_request_from_auth_url(auth_url, auth_options)
       uri = URI.parse(auth_url)
       connection = Faraday.new("#{uri.scheme}://#{uri.host}", connection_options)
-      method = options[:auth_method] || :get
+      method = auth_options[:auth_method] || :get
 
       response = connection.send(method) do |request|
         request.url uri.path

--- a/lib/ably/auth.rb
+++ b/lib/ably/auth.rb
@@ -458,11 +458,11 @@ module Ably
 
       response = connection.send(method) do |request|
         request.url uri.path
-        request.params = options[:auth_params] || {}
-        request.headers = options[:auth_headers] || {}
+        request.params = CGI.parse(uri.query || '').merge(auth_options[:auth_params] || {})
+        request.headers = auth_options[:auth_headers] || {}
       end
 
-      if !response.body.kind_of?(Hash) && response.headers['Content-Type'] != 'text/plain'
+      if !response.body.kind_of?(Hash) && !response.headers['Content-Type'].to_s.match(%r{text/plain}i)
         raise Ably::Exceptions::InvalidResponseBody,
               "Content Type #{response.headers['Content-Type']} is not supported by this client library"
       end

--- a/lib/ably/realtime/auth.rb
+++ b/lib/ably/realtime/auth.rb
@@ -21,6 +21,8 @@ module Ably
     #   (see Ably::Auth#key_secret)
     # @!attribute [r] options
     #   (see Ably::Auth#options)
+    # @!attribute [r] token_params
+    #   (see Ably::Auth#options)
     # @!attribute [r] using_basic_auth?
     #   (see Ably::Auth#using_basic_auth?)
     # @!attribute [r] using_token_auth?
@@ -36,7 +38,7 @@ module Ably
 
       def_delegators :auth_sync, :client_id
       def_delegators :auth_sync, :current_token_details, :token
-      def_delegators :auth_sync, :key, :key_name, :key_secret, :options
+      def_delegators :auth_sync, :key, :key_name, :key_secret, :options, :auth_options, :token_params
       def_delegators :auth_sync, :using_basic_auth?, :using_token_auth?
       def_delegators :auth_sync, :token_renewable?, :authentication_security_requirements_met?
       def_delegators :client, :logger
@@ -63,9 +65,9 @@ module Ably
       #      token_details #=> Ably::Models::TokenDetails
       #    end
       #
-      def authorise(options = {}, &success_callback)
+      def authorise(auth_options = {}, token_params = {}, &success_callback)
         async_wrap(success_callback) do
-          auth_sync.authorise(options)
+          auth_sync.authorise(auth_options, token_params)
         end
       end
 
@@ -74,8 +76,8 @@ module Ably
       # @option (see Ably::Auth#authorise)
       # @return [Ably::Models::TokenDetails]
       #
-      def authorise_sync(options = {})
-        auth_sync.authorise(options)
+      def authorise_sync(auth_options = {}, token_params = {})
+        auth_sync.authorise(auth_options, token_params)
       end
 
       # def_delegator :auth_sync, :request_token, :request_token_sync
@@ -98,9 +100,9 @@ module Ably
       #      token_details #=> Ably::Models::TokenDetails
       #    end
       #
-      def request_token(options = {}, &success_callback)
+      def request_token(auth_options = {}, token_params = {}, &success_callback)
         async_wrap(success_callback) do
-          request_token_sync(options)
+          request_token_sync(auth_options, token_params)
         end
       end
 
@@ -109,8 +111,8 @@ module Ably
       # @option (see Ably::Auth#authorise)
       # @return [Ably::Models::TokenDetails]
       #
-      def request_token_sync(options = {})
-        auth_sync.request_token(options)
+      def request_token_sync(auth_options = {}, token_params = {})
+        auth_sync.request_token(auth_options, token_params)
       end
 
       # Creates and signs a token request that can then subsequently be used by any client to request a token
@@ -125,9 +127,9 @@ module Ably
       #   client.auth.create_token_request(id: 'asd.asd', ttl: 3600) do |token_request|
       #     token_request #=> Ably::Models::TokenRequest
       #   end
-      def create_token_request(options = {}, &success_callback)
+      def create_token_request(auth_options = {}, token_params = {}, &success_callback)
         async_wrap(success_callback) do
-          create_token_request_sync(options)
+          create_token_request_sync(auth_options, token_params)
         end
       end
 
@@ -136,8 +138,8 @@ module Ably
       # @option (see Ably::Auth#authorise)
       # @return [Ably::Models::TokenRequest]
       #
-      def create_token_request_sync(options = {})
-        auth_sync.create_token_request(options)
+      def create_token_request_sync(auth_options = {}, token_params = {})
+        auth_sync.create_token_request(auth_options, token_params)
       end
 
       # Auth header string used in HTTP requests to Ably

--- a/spec/acceptance/realtime/auth_spec.rb
+++ b/spec/acceptance/realtime/auth_spec.rb
@@ -97,10 +97,11 @@ describe Ably::Realtime::Auth, :event_machine do
       end
 
       context '#options (auth_options)' do
-        let(:auth_url) { random_str }
+        let(:auth_url) { "https://echo.ably.io/?type=text" }
+        let(:auth_params) { { :body => random_str } }
 
         it 'contains the configured auth options' do
-          auth.authorise(auth_url: auth_url) do
+          auth.authorise(auth_url: auth_url, auth_params: auth_params) do
             expect(auth.options[:auth_url]).to eql(auth_url)
             stop_reactor
           end

--- a/spec/acceptance/realtime/channels_spec.rb
+++ b/spec/acceptance/realtime/channels_spec.rb
@@ -1,0 +1,64 @@
+# encoding: utf-8
+require 'spec_helper'
+
+describe Ably::Realtime::Channels do
+  shared_examples 'a channel' do
+    it 'returns a channel object' do
+      expect(channel).to be_a Ably::Realtime::Channel
+      expect(channel.name).to eql(channel_name)
+    end
+
+    it 'returns channel object and passes the provided options' do
+      expect(channel_with_options.options).to eql(options)
+    end
+  end
+
+  vary_by_protocol do
+    let(:client) do
+      Ably::Realtime::Client.new(key: api_key, environment: environment, protocol: protocol)
+    end
+    let(:channel_name) { random_str }
+    let(:options)      { { key: 'value' } }
+
+    describe 'using shortcut method #channel on the client object' do
+      let(:channel) { client.channel(channel_name) }
+      let(:channel_with_options) { client.channel(channel_name, options) }
+      it_behaves_like 'a channel'
+    end
+
+    describe 'using #get method on client#channels' do
+      let(:channel) { client.channels.get(channel_name) }
+      let(:channel_with_options) { client.channels.get(channel_name, options) }
+      it_behaves_like 'a channel'
+    end
+
+    describe 'accessing an existing channel object with different options' do
+      let(:new_channel_options) { { encrypted: true } }
+      let(:original_channel)    { client.channels.get(channel_name, options) }
+
+      it 'overrides the existing channel options and returns the channel object' do
+        expect(original_channel.options).to_not include(:encrypted)
+        new_channel = client.channels.get(channel_name, new_channel_options)
+        expect(new_channel).to be_a(Ably::Realtime::Channel)
+        expect(new_channel.options[:encrypted]).to eql(true)
+      end
+    end
+
+    describe 'accessing an existing channel object without specifying any channel options' do
+      let(:original_channel) { client.channels.get(channel_name, options) }
+
+      it 'returns the existing channel without modifying the channel options' do
+        expect(original_channel.options).to eql(options)
+        new_channel = client.channels.get(channel_name)
+        expect(new_channel).to be_a(Ably::Realtime::Channel)
+        expect(original_channel.options).to eql(options)
+      end
+    end
+
+    describe 'using undocumented array accessor [] method on client#channels' do
+      let(:channel) { client.channels[channel_name] }
+      let(:channel_with_options) { client.channels[channel_name, options] }
+      it_behaves_like 'a channel'
+    end
+  end
+end

--- a/spec/acceptance/realtime/connection_spec.rb
+++ b/spec/acceptance/realtime/connection_spec.rb
@@ -96,7 +96,7 @@ describe Ably::Realtime::Connection, :event_machine do
               stub_const 'Ably::Auth::TOKEN_DEFAULTS', Ably::Auth::TOKEN_DEFAULTS.merge(renew_token_buffer: 0)
 
               # Authorise synchronously to ensure token has been issued
-              client.auth.authorise_sync(ttl: ttl)
+              client.auth.authorise_sync(token_params: { ttl: ttl })
             end
 
             let(:original_renew_token_buffer) { @original_renew_token_buffer }
@@ -200,7 +200,7 @@ describe Ably::Realtime::Connection, :event_machine do
 
             let!(:expired_token_details) do
               # Request a token synchronously
-              Ably::Realtime::Client.new(default_options).auth.request_token_sync(ttl: 0.01)
+              Ably::Realtime::Client.new(default_options).auth.request_token_sync(token_params: { ttl: 0.01 })
             end
 
             context 'opening a new connection' do

--- a/spec/acceptance/rest/auth_spec.rb
+++ b/spec/acceptance/rest/auth_spec.rb
@@ -204,12 +204,12 @@ describe Ably::Auth do
         let(:query_params)      { nil }
         let(:headers)           { nil }
         let(:auth_method)       { :get }
-        let(:token_params) do
+        let(:auth_options) do
           {
-            auth_url: auth_url,
-            auth_params: query_params,
+            auth_url:     auth_url,
+            auth_params:  query_params,
             auth_headers: headers,
-            auth_method: auth_method
+            auth_method:  auth_method
           }
         end
 
@@ -237,7 +237,7 @@ describe Ably::Auth do
         end
 
         context 'when response from :auth_url is a valid token request' do
-          let!(:token) { auth.request_token(token_params: token_params) }
+          let!(:token) { auth.request_token(auth_options) }
 
           it 'requests a token from :auth_url using an HTTP GET request' do
             expect(request_token_stub).to have_been_requested
@@ -290,9 +290,10 @@ describe Ably::Auth do
             }.to_json
           end
 
-          let!(:token_details) { auth.request_token({}, token_params) }
+          let!(:token_details) { auth.request_token(auth_options) }
 
           it 'returns TokenDetails created from the token JSON' do
+            expect(auth_url_request_stub).to have_been_requested
             expect(request_token_stub).to_not have_been_requested
             expect(token_details).to be_a(Ably::Models::TokenDetails)
             expect(token_details.token).to eql(token)
@@ -307,9 +308,10 @@ describe Ably::Auth do
           let(:auth_url_content_type) { 'text/plain' }
           let(:auth_url_response) { token }
 
-          let!(:token_details) { auth.request_token(token_params: token_params) }
+          let!(:token_details) { auth.request_token(auth_options) }
 
           it 'returns TokenDetails created from the token JSON' do
+            expect(auth_url_request_stub).to have_been_requested
             expect(request_token_stub).to_not have_been_requested
             expect(token_details).to be_a(Ably::Models::TokenDetails)
             expect(token_details.token).to eql(token)
@@ -323,7 +325,7 @@ describe Ably::Auth do
             end
 
             it 'raises ServerError' do
-              expect { auth.request_token token_params: token_params }.to raise_error(Ably::Exceptions::ServerError)
+              expect { auth.request_token auth_options }.to raise_error(Ably::Exceptions::ServerError)
             end
           end
 
@@ -334,7 +336,7 @@ describe Ably::Auth do
             end
 
             it 'raises InvalidResponseBody' do
-              expect { auth.request_token token_params: token_params }.to raise_error(Ably::Exceptions::InvalidResponseBody)
+              expect { auth.request_token auth_options }.to raise_error(Ably::Exceptions::InvalidResponseBody)
             end
           end
         end

--- a/spec/acceptance/rest/channel_spec.rb
+++ b/spec/acceptance/rest/channel_spec.rb
@@ -56,7 +56,7 @@ describe Ably::Rest::Channel do
 
       context 'without adequate permissions on the channel' do
         let(:capability)     { { onlyChannel: ['subscribe'] } }
-        let(:client_options) { default_options.merge(use_token_auth: true, capability: capability) }
+        let(:client_options) { default_options.merge(use_token_auth: true, token_params: { capability: capability }) }
 
         it 'raises a permission error when publishing' do
           expect { channel.publish(name, data) }.to raise_error(Ably::Exceptions::InvalidRequest, /not permitted/)

--- a/spec/acceptance/rest/client_spec.rb
+++ b/spec/acceptance/rest/client_spec.rb
@@ -64,11 +64,13 @@ describe Ably::Rest::Client do
       end
 
       context 'with an auth URL' do
-        let(:client_options) { default_options.merge(auth_url: token_request_url, auth_method: :get) }
+        let(:client_options)    { default_options.merge(key: api_key, auth_url: token_request_url, auth_method: :get) }
         let(:token_request_url) { 'http://get.token.request.com/' }
 
         before do
-          allow(client.auth).to receive(:token_request_from_auth_url).with(token_request_url, :auth_method => :get).and_return(token_request)
+          expect(client.auth).to receive(:token_request_from_auth_url).with(token_request_url, :auth_method => :get).once do
+            client.auth.create_token_request(token_params: { client_id: client_id })
+          end
         end
 
         it 'sends an HTTP request to the provided URL to get a new token' do
@@ -152,7 +154,7 @@ describe Ably::Rest::Client do
           stub_const 'Ably::Auth::TOKEN_DEFAULTS', Ably::Auth::TOKEN_DEFAULTS.merge(renew_token_buffer: 0)
         end
 
-        let(:token_request_options) { { key_name: key_name, key_secret: key_secret, ttl: Ably::Models::TokenDetails::TOKEN_EXPIRY_BUFFER } }
+        let(:token_request_options) { { key_name: key_name, key_secret: key_secret, token_params: { ttl: Ably::Models::TokenDetails::TOKEN_EXPIRY_BUFFER } } }
 
         it 'creates a new token automatically when the old token expires' do
           expect { client.channel('channel_name').publish('event', 'message') }.to change { client.auth.current_token_details }

--- a/spec/acceptance/rest/client_spec.rb
+++ b/spec/acceptance/rest/client_spec.rb
@@ -67,19 +67,21 @@ describe Ably::Rest::Client do
         let(:client_options)    { default_options.merge(key: api_key, auth_url: token_request_url, auth_method: :get) }
         let(:token_request_url) { 'http://get.token.request.com/' }
 
-        before do
-          expect(client.auth).to receive(:token_request_from_auth_url).with(token_request_url, :auth_method => :get).once do
-            client.auth.create_token_request(token_params: { client_id: client_id })
-          end
-        end
-
-        it 'sends an HTTP request to the provided URL to get a new token' do
-          expect { client.channel('channel_name').publish('event', 'message') }.to change { client.auth.current_token_details }
-          expect(client.auth.current_token_details.client_id).to eql(client_id)
-        end
-
         it 'uses token authentication' do
           expect(client.auth).to be_using_token_auth
+        end
+
+        context 'before any REST request' do
+          before do
+            expect(client.auth).to receive(:token_request_from_auth_url).with(token_request_url, hash_including(:auth_method => :get)).once do
+              client.auth.create_token_request(token_params: { client_id: client_id })
+            end
+          end
+
+          it 'sends an HTTP request to the provided auth URL to get a new token' do
+            expect { client.channel('channel_name').publish('event', 'message') }.to change { client.auth.current_token_details }
+            expect(client.auth.current_token_details.client_id).to eql(client_id)
+          end
         end
       end
 

--- a/spec/shared/client_initializer_behaviour.rb
+++ b/spec/shared/client_initializer_behaviour.rb
@@ -145,6 +145,15 @@ shared_examples 'a client initializer' do
       end
     end
 
+    context 'with token_params' do
+      let(:client_options) { { token_params: { ttl: 777, client_id: 'john' }, token: 'token' } }
+
+      it 'configures the default token_params' do
+        expect(subject.auth.token_params.fetch(:ttl)).to eql(777)
+        expect(subject.auth.token_params.fetch(:client_id)).to eql('john')
+      end
+    end
+
     context 'endpoint' do
       it 'defaults to production' do
         expect(subject.endpoint.to_s).to eql("#{protocol}s://#{subdomain}.ably.io")

--- a/spec/unit/auth_spec.rb
+++ b/spec/unit/auth_spec.rb
@@ -2,12 +2,13 @@ require 'spec_helper'
 require 'shared/protocol_msgbus_behaviour'
 
 describe Ably::Auth do
-  let(:client)    { double('client').as_null_object }
-  let(:client_id) { nil }
-  let(:options)   { { key: 'appid.keyuid:keysecret', client_id: client_id } }
+  let(:client)        { double('client').as_null_object }
+  let(:client_id)     { nil }
+  let(:auth_options)  { { key: 'appid.keyuid:keysecret', client_id: client_id } }
+  let(:token_params)  { { } }
 
   subject do
-    Ably::Auth.new(client, options)
+    Ably::Auth.new(client, auth_options, token_params)
   end
 
   describe 'client_id option' do


### PR DESCRIPTION
@paddybyers following our chat a little while ago about how I had merged auth options and token params into a single argument, I have now split them, addressing https://github.com/ably/ably-ruby/issues/55

I am doing this so that the Realtime spec is valid for Ruby...

Not expecting a reply, just wanted you to see