### PR TITLE
Allow clientId to be provided on init if using externally created token

### DIFF
--- a/lib/ably/auth.rb
+++ b/lib/ably/auth.rb
@@ -74,7 +74,7 @@ module Ably
         raise ArgumentError, 'key is missing. Either an API key, token, or token auth method must be provided'
       end
 
-      if has_client_id?
+      if has_client_id? && !token_creatable_externally?
         raise ArgumentError, 'client_id cannot be provided without a complete API key. Key name & Secret is needed to authenticate with Ably and obtain a token' unless api_key_present?
         ensure_utf_8 :client_id, client_id
       end

--- a/spec/acceptance/rest/client_spec.rb
+++ b/spec/acceptance/rest/client_spec.rb
@@ -63,6 +63,16 @@ describe Ably::Rest::Client do
         end
       end
 
+      context 'with an :auth_callback Proc (clientId provided in library options instead of as a token_request param)' do
+        let(:client) { Ably::Rest::Client.new(client_options.merge(client_id: client_id, auth_callback: Proc.new { token_request })) }
+        let(:token_request) { client.auth.create_token_request(key_name: key_name, key_secret: key_secret) }
+
+        it 'correctly sets the clientId on the token' do
+          expect { client.channel('channel_name').publish('event', 'message') }.to change { client.auth.current_token_details }
+          expect(client.auth.current_token_details.client_id).to eql(client_id)
+        end
+      end
+
       context 'with an auth URL' do
         let(:client_options)    { default_options.merge(key: api_key, auth_url: token_request_url, auth_method: :get) }
         let(:token_request_url) { 'http://get.token.request.com/' }


### PR DESCRIPTION
Thought I'd add a test to check ably-ruby didn't have the problem of https://github.com/ably/ably-js/issues/108 , needed a tweak to make it pass