### PR TITLE
Ensure connections are always closed in tests

### DIFF
--- a/lib/ably/auth.rb
+++ b/lib/ably/auth.rb
@@ -401,7 +401,11 @@ module Ably
 
     # Returns the current token if it exists or authorises and retrieves a token
     def token_auth_string
-      if token
+      # If a TokenDetails object has been issued by this library
+      # then that Token will take precedence
+      if @current_token_details
+        authorise.token
+      elsif token # token string was configured in the options
         token
       else
         authorise.token

--- a/lib/ably/models/token_details.rb
+++ b/lib/ably/models/token_details.rb
@@ -34,7 +34,7 @@ module Ably::Models
     # @param attributes
     # @option attributes [String]       :token      token used to authenticate requests
     # @option attributes [String]       :key_name   API key name used to create this token
-    # @option attributes [Time,Integer] :issued  Time the token was issued as Time or Integer in milliseconds
+    # @option attributes [Time,Integer] :issued     Time the token was issued as Time or Integer in milliseconds
     # @option attributes [Time,Integer] :expires    Time the token expires as Time or Integer in milliseconds
     # @option attributes [String]       :capability JSON stringified capabilities assigned to this token
     # @option attributes [String]       :client_id  client ID assigned to this token
@@ -52,31 +52,31 @@ module Ably::Models
     # @!attribute [r] token
     # @return [String] Token used to authenticate requests
     def token
-      hash.fetch(:token)
+      hash[:token]
     end
 
     # @!attribute [r] key_name
     # @return [String] API key name used to create this token.  An API key is made up of an API key name and secret delimited by a +:+
     def key_name
-      hash.fetch(:key_name)
+      hash[:key_name]
     end
 
     # @!attribute [r] issued
     # @return [Time] Time the token was issued
     def issued
-      as_time_from_epoch(hash.fetch(:issued), granularity: :ms)
+      as_time_from_epoch(hash[:issued], granularity: :ms, allow_nil: :true)
     end
 
     # @!attribute [r] expires
     # @return [Time] Time the token expires
     def expires
-      as_time_from_epoch(hash.fetch(:expires), granularity: :ms)
+      as_time_from_epoch(hash[:expires], granularity: :ms, allow_nil: :true)
     end
 
     # @!attribute [r] capability
     # @return [Hash] Capabilities assigned to this token
     def capability
-      JSON.parse(hash.fetch(:capability))
+      JSON.parse(hash.fetch(:capability)) if hash.fetch(:capability)
     end
 
     # @!attribute [r] client_id
@@ -86,9 +86,11 @@ module Ably::Models
     end
 
     # Returns true if token is expired or about to expire
+    # For tokens that have not got an explicit expires attribute expired? will always return true
     #
     # @return [Boolean]
     def expired?
+      return false if !expires
       expires < Time.now + TOKEN_EXPIRY_BUFFER
     end
 

--- a/lib/ably/modules/conversions.rb
+++ b/lib/ably/modules/conversions.rb
@@ -6,6 +6,8 @@ module Ably::Modules
 
     private
     def as_since_epoch(time, options = {})
+      return nil if options[:allow_nil] && !time
+
       granularity = options.fetch(:granularity, :ms)
 
       case time
@@ -19,6 +21,8 @@ module Ably::Modules
     end
 
     def as_time_from_epoch(time, options = {})
+      return nil if options[:allow_nil] && !time
+
       granularity = options.fetch(:granularity, :ms)
 
       case time

--- a/lib/ably/modules/state_emitter.rb
+++ b/lib/ably/modules/state_emitter.rb
@@ -142,7 +142,7 @@ module Ably::Modules
     def deferrable_for_state_change_to(target_state)
       Ably::Util::SafeDeferrable.new(logger).tap do |deferrable|
         fail_proc = Proc.new do |state_change|
-          deferrable.fail self, state_change.reason
+          deferrable.fail state_change.reason
         end
         once_or_if(target_state, else: fail_proc) do
           yield self if block_given?

--- a/lib/ably/modules/uses_state_machine.rb
+++ b/lib/ably/modules/uses_state_machine.rb
@@ -86,12 +86,19 @@ module Ably::Modules
     module ClassMethods
       def emits_klass
         @emits_klass ||= if @emits_klass_name
-          Object.const_get @emits_klass_name
+          get_const(@emits_klass_name)
         end
       end
 
       def ensure_state_machine_emits(klass)
         @emits_klass_name = klass
+      end
+
+      def get_const(klass_name)
+        klass_names = klass_name.split('::')
+        klass_names.inject(Kernel) do |klass, name|
+          klass.const_get(name)
+        end
       end
     end
   end

--- a/lib/ably/realtime/channel.rb
+++ b/lib/ably/realtime/channel.rb
@@ -134,7 +134,7 @@ module Ably
       #     puts "#{message.name} event received with #{message.data}"
       #   end
       #
-      #   channel.publish('click', 'body').errback do |message, error|
+      #   channel.publish('click', 'body').errback do |error, message|
       #     puts "#{message.name} was not received, error #{error.message}"
       #   end
       #
@@ -155,7 +155,7 @@ module Ably
         end
 
         queue_messages(messages).tap do |deferrable|
-          deferrable.callback &success_block if block_given?
+          deferrable.callback(&success_block) if block_given?
         end
       end
 

--- a/lib/ably/realtime/channel/channel_manager.rb
+++ b/lib/ably/realtime/channel/channel_manager.rb
@@ -77,10 +77,10 @@ module Ably::Realtime
       def nack_messages(protocol_message, error)
         (protocol_message.messages + protocol_message.presence).each do |message|
           logger.debug "Calling NACK failure callbacks for #{message.class.name} - #{message.to_json}, protocol message: #{protocol_message}"
-          message.fail message, error
+          message.fail error
         end
         logger.debug "Calling NACK failure callbacks for #{protocol_message.class.name} - #{protocol_message.to_json}"
-        protocol_message.fail protocol_message, error
+        protocol_message.fail error
       end
 
       def drop_pending_queue_from_ack(ack_protocol_message)

--- a/lib/ably/realtime/channel/channel_manager.rb
+++ b/lib/ably/realtime/channel/channel_manager.rb
@@ -146,7 +146,7 @@ module Ably::Realtime
         end
 
         connection.unsafe_on(:failed) do |error|
-          if can_transition_to?(:failed)
+          if can_transition_to?(:failed) && !channel.detached?
             channel.transition_state_machine :failed, reason: Ably::Exceptions::ConnectionFailed.new('Connection failed', nil, 80002, error)
           end
         end

--- a/lib/ably/realtime/channel/channel_state_machine.rb
+++ b/lib/ably/realtime/channel/channel_state_machine.rb
@@ -24,6 +24,7 @@ module Ably::Realtime
       transition :from => :attaching,    :to => [:attached, :detaching, :failed]
       transition :from => :attached,     :to => [:detaching, :detached, :failed]
       transition :from => :detaching,    :to => [:detached, :attaching, :failed]
+      transition :from => :detached,     :to => [:attaching, :attached, :failed]
       transition :from => :failed,       :to => [:attaching]
 
       after_transition do |channel, transition|

--- a/lib/ably/realtime/client/incoming_message_dispatcher.rb
+++ b/lib/ably/realtime/client/incoming_message_dispatcher.rb
@@ -175,11 +175,11 @@ module Ably::Realtime
 
       def drop_pending_queue_from_ack(ack_protocol_message)
         message_serial_up_to = ack_protocol_message.message_serial + ack_protocol_message.count - 1
-        connection.__pending_message_ack_queue__.drop_while do |protocol_message|
-          if protocol_message.message_serial <= message_serial_up_to
-            yield protocol_message
-            true
-          end
+
+        while !connection.__pending_message_ack_queue__.empty?
+          next_message = connection.__pending_message_ack_queue__.first
+          return if next_message.message_serial > message_serial_up_to
+          yield connection.__pending_message_ack_queue__.shift
         end
       end
 

--- a/lib/ably/realtime/client/incoming_message_dispatcher.rb
+++ b/lib/ably/realtime/client/incoming_message_dispatcher.rb
@@ -163,7 +163,7 @@ module Ably::Realtime
       def nack_messages(messages, protocol_message)
         messages.each do |message|
           logger.debug "Calling NACK failure callbacks for #{message.class.name} - #{message.to_json}, protocol message: #{protocol_message}"
-          message.fail message, protocol_message.error
+          message.fail protocol_message.error
         end
       end
 

--- a/lib/ably/realtime/client/outgoing_message_dispatcher.rb
+++ b/lib/ably/realtime/client/outgoing_message_dispatcher.rb
@@ -44,6 +44,12 @@ module Ably::Realtime
 
         non_blocking_loop_while(condition) do
           protocol_message = outgoing_queue.shift
+
+          if (!connection.transport)
+            protocol_message.fail Ably::Exceptions::TransportClosed.new('Transport disconnected unexpectedly', nil, 80003)
+            next
+          end
+
           current_transport_outgoing_message_bus.publish :protocol_message, protocol_message
 
           if protocol_message.ack_required?

--- a/lib/ably/realtime/connection.rb
+++ b/lib/ably/realtime/connection.rb
@@ -119,7 +119,7 @@ module Ably
       # the failed state. Once closed, the library will not attempt to re-establish the
       # connection without a call to {Connection#connect}.
       #
-      # @yield [Ably::Realtime::Connection] block is called as soon as this connection is in the Closed state
+      # @yield block is called as soon as this connection is in the Closed state
       #
       # @return [EventMachine::Deferrable]
       #
@@ -134,7 +134,7 @@ module Ably
       # Causes the library to attempt connection.  If it was previously explicitly
       # closed by the user, or was closed as a result of an unrecoverable error, a new connection will be opened.
       #
-      # @yield [Ably::Realtime::Connection] block is called as soon as this connection is in the Connected state
+      # @yield block is called as soon as this connection is in the Connected state
       #
       # @return [EventMachine::Deferrable]
       #
@@ -190,7 +190,7 @@ module Ably
           EventMachine::HttpRequest.new(url).get.tap do |http|
             http.errback do
               yield false if block_given?
-              deferrable.fail "Unable to connect to #{url}"
+              deferrable.fail Ably::Exceptions::ConnectionFailed.new("Unable to connect to #{url}", nil, 80000)
             end
             http.callback do
               EventMachine.next_tick do
@@ -199,7 +199,7 @@ module Ably
                 if result
                   deferrable.succeed
                 else
-                  deferrable.fail "Unexpected response from #{url} (#{http.response_header.status})"
+                  deferrable.fail Ably::Exceptions::ConnectionFailed.new("Unexpected response from #{url} (#{http.response_header.status})", 400, 40000)
                 end
               end
             end

--- a/lib/ably/realtime/connection/connection_manager.rb
+++ b/lib/ably/realtime/connection/connection_manager.rb
@@ -39,7 +39,7 @@ module Ably::Realtime
 
         EventMachine.next_tick do
           # Connect once Connection object is initialised
-          connection.connect if client.auto_connect
+          connection.connect if client.auto_connect && connection.can_transition_to?(:connecting)
         end
       end
 
@@ -179,7 +179,7 @@ module Ably::Realtime
       #
       # @api private
       def respond_to_transport_disconnected_whilst_connected(error)
-        logger.warn "ConnectionManager: Connection to #{connection.transport.url} was disconnected unexpectedly"
+        logger.warn "ConnectionManager: Connection #{"to #{connection.transport.url}" if connection.transport} was disconnected unexpectedly"
 
         if error.kind_of?(Ably::Models::ErrorInfo) && error.code != RESOLVABLE_ERROR_CODES.fetch(:token_expired)
           connection.emit :error, error

--- a/lib/ably/realtime/connection/connection_state_machine.rb
+++ b/lib/ably/realtime/connection/connection_state_machine.rb
@@ -57,7 +57,7 @@ module Ably::Realtime
         connection.manager.respond_to_transport_disconnected_when_connecting err
       end
 
-      after_transition(to: [:disconnected], from: [:connected]) do |connection, current_transition|
+      after_transition(to: [:disconnected, :suspended], from: [:connected]) do |connection, current_transition|
         err = error_from_state_change(current_transition)
         connection.manager.respond_to_transport_disconnected_whilst_connected err
       end

--- a/lib/ably/realtime/presence.rb
+++ b/lib/ably/realtime/presence.rb
@@ -405,7 +405,7 @@ module Ably::Realtime
           deferrable_succeed deferrable, &success_block
         end
 
-        protocol_message.errback do |message, error|
+        protocol_message.errback do |error|
           change_state failed_state, error if failed_state
           deferrable_fail deferrable, error
         end
@@ -419,8 +419,8 @@ module Ably::Realtime
     end
 
     def deferrable_fail(deferrable, *args, &block)
-      safe_yield block, self, *args if block_given?
-      EventMachine.next_tick { deferrable.fail self, *args } # allow errback to be added to the returned Deferrable
+      safe_yield block, *args if block_given?
+      EventMachine.next_tick { deferrable.fail *args } # allow errback to be added to the returned Deferrable
       deferrable
     end
 
@@ -431,7 +431,7 @@ module Ably::Realtime
       ensure_channel_attached(deferrable) do
         send_presence_protocol_message(action, client_id, options).tap do |protocol_message|
           protocol_message.callback { |message| deferrable_succeed deferrable, &success_block }
-          protocol_message.errback  { |message, error| deferrable_fail deferrable, error }
+          protocol_message.errback  { |error| deferrable_fail deferrable, error }
         end
       end
     end

--- a/spec/acceptance/realtime/auth_spec.rb
+++ b/spec/acceptance/realtime/auth_spec.rb
@@ -8,7 +8,7 @@ describe Ably::Realtime::Auth, :event_machine do
   vary_by_protocol do
     let(:default_options) { { key: api_key, environment: environment, protocol: protocol } }
     let(:client_options)  { default_options }
-    let(:client)          { Ably::Realtime::Client.new(client_options) }
+    let(:client)          { auto_close Ably::Realtime::Client.new(client_options) }
     let(:auth)            { client.auth }
 
     context 'with basic auth' do

--- a/spec/acceptance/realtime/channel_history_spec.rb
+++ b/spec/acceptance/realtime/channel_history_spec.rb
@@ -5,11 +5,11 @@ describe Ably::Realtime::Channel, '#history', :event_machine do
   vary_by_protocol do
     let(:default_options) { options.merge(key: api_key, environment: environment, protocol: protocol) }
 
-    let(:client)       { Ably::Realtime::Client.new(default_options) }
+    let(:client)       { auto_close Ably::Realtime::Client.new(default_options) }
     let(:channel)      { client.channel(channel_name) }
     let(:rest_channel) { client.rest_client.channel(channel_name) }
 
-    let(:client2)      { Ably::Realtime::Client.new(default_options) }
+    let(:client2)      { auto_close Ably::Realtime::Client.new(default_options) }
     let(:channel2)     { client2.channel(channel_name) }
 
     let(:channel_name) { "persisted:#{random_str(2)}" }

--- a/spec/acceptance/realtime/channel_spec.rb
+++ b/spec/acceptance/realtime/channel_spec.rb
@@ -80,7 +80,7 @@ describe Ably::Realtime::Channel, :event_machine do
       end
 
       it 'calls the SafeDeferrable callback on success' do
-        channel.attach.callback do |channel|
+        channel.attach.callback do
           expect(channel).to be_a(Ably::Realtime::Channel)
           expect(channel.state).to eq(:attached)
           stop_reactor
@@ -162,7 +162,7 @@ describe Ably::Realtime::Channel, :event_machine do
         end
 
         it 'calls the errback of the returned Deferrable' do
-          restricted_channel.attach.errback do |channel, error|
+          restricted_channel.attach.errback do |error|
             expect(restricted_channel.state).to eq(:failed)
             expect(error.status).to eq(401)
             stop_reactor
@@ -220,9 +220,10 @@ describe Ably::Realtime::Channel, :event_machine do
       end
 
       it 'detaches from a channel and calls the provided block' do
-        channel.attach do |chan|
-          chan.detach do |detached_chan|
-            expect(detached_chan.state).to eq(:detached)
+        channel.attach do
+          expect(channel.state).to eq(:attached)
+          channel.detach do
+            expect(channel.state).to eq(:detached)
             stop_reactor
           end
         end
@@ -249,7 +250,7 @@ describe Ably::Realtime::Channel, :event_machine do
 
       it 'calls the Deferrable callback on success' do
         channel.attach do
-          channel.detach.callback do |channel|
+          channel.detach.callback do
             expect(channel).to be_a(Ably::Realtime::Channel)
             expect(channel.state).to eq(:detached)
             stop_reactor

--- a/spec/acceptance/realtime/channel_spec.rb
+++ b/spec/acceptance/realtime/channel_spec.rb
@@ -6,7 +6,7 @@ describe Ably::Realtime::Channel, :event_machine do
     let(:default_options) { { key: api_key, environment: environment, protocol: protocol } }
     let(:client_options)  { default_options }
 
-    let(:client)       { Ably::Realtime::Client.new(client_options) }
+    let(:client)       { auto_close Ably::Realtime::Client.new(client_options) }
     let(:channel_name) { random_str }
     let(:payload)      { random_str }
     let(:channel)      { client.channel(channel_name) }
@@ -15,7 +15,7 @@ describe Ably::Realtime::Channel, :event_machine do
     describe 'initialization' do
       context 'with :auto_connect option set to false on connection' do
         let(:client) do
-          Ably::Realtime::Client.new(default_options.merge(auto_connect: false))
+          auto_close Ably::Realtime::Client.new(default_options.merge(auto_connect: false))
         end
 
         it 'remains initialized when accessing a channel' do
@@ -131,7 +131,7 @@ describe Ably::Realtime::Channel, :event_machine do
 
         it 'attaches all channels', em_timeout: 15 do
           connection_count.times.map do
-            Ably::Realtime::Client.new(default_options)
+            auto_close Ably::Realtime::Client.new(default_options)
           end.each do |client|
             channel_count.times.map do |index|
               client.channel("channel-#{index}").attach do
@@ -148,7 +148,7 @@ describe Ably::Realtime::Channel, :event_machine do
 
       context 'failure as a result of insufficient key permissions' do
         let(:restricted_client) do
-          Ably::Realtime::Client.new(default_options.merge(key: restricted_api_key, log_level: :fatal))
+          auto_close Ably::Realtime::Client.new(default_options.merge(key: restricted_api_key, log_level: :fatal))
         end
         let(:restricted_channel) { restricted_client.channel("cannot_subscribe") }
 
@@ -563,7 +563,7 @@ describe Ably::Realtime::Channel, :event_machine do
 
         it 'publishes all messages, all success callbacks are called, and a history request confirms all messages were published' do
           connection_count.times.map do
-            Ably::Realtime::Client.new(client_options)
+            auto_close Ably::Realtime::Client.new(client_options)
           end.each do |client|
             channel = client.channels.get(channel_name)
             messages.each do |message|

--- a/spec/acceptance/realtime/channels_spec.rb
+++ b/spec/acceptance/realtime/channels_spec.rb
@@ -1,21 +1,23 @@
 # encoding: utf-8
 require 'spec_helper'
 
-describe Ably::Realtime::Channels do
+describe Ably::Realtime::Channels, :event_machine do
   shared_examples 'a channel' do
     it 'returns a channel object' do
       expect(channel).to be_a Ably::Realtime::Channel
       expect(channel.name).to eql(channel_name)
+      stop_reactor
     end
 
     it 'returns channel object and passes the provided options' do
       expect(channel_with_options.options).to eql(options)
+      stop_reactor
     end
   end
 
   vary_by_protocol do
     let(:client) do
-      Ably::Realtime::Client.new(key: api_key, environment: environment, protocol: protocol)
+      auto_close Ably::Realtime::Client.new(key: api_key, environment: environment, protocol: protocol)
     end
     let(:channel_name) { random_str }
     let(:options)      { { key: 'value' } }
@@ -41,6 +43,7 @@ describe Ably::Realtime::Channels do
         new_channel = client.channels.get(channel_name, new_channel_options)
         expect(new_channel).to be_a(Ably::Realtime::Channel)
         expect(new_channel.options[:encrypted]).to eql(true)
+        stop_reactor
       end
     end
 
@@ -52,6 +55,7 @@ describe Ably::Realtime::Channels do
         new_channel = client.channels.get(channel_name)
         expect(new_channel).to be_a(Ably::Realtime::Channel)
         expect(original_channel.options).to eql(options)
+        stop_reactor
       end
     end
 

--- a/spec/acceptance/realtime/client_spec.rb
+++ b/spec/acceptance/realtime/client_spec.rb
@@ -11,7 +11,7 @@ describe Ably::Realtime::Client, :event_machine do
     let(:connection)     { subject.connection }
     let(:auth_params)    { subject.auth.auth_params_sync }
 
-    subject              { Ably::Realtime::Client.new(client_options) }
+    subject              { auto_close Ably::Realtime::Client.new(client_options) }
 
     context 'initialization' do
       context 'basic auth' do
@@ -44,7 +44,8 @@ describe Ably::Realtime::Client, :event_machine do
         [true, false].each do |tls_enabled|
           context "with TLS #{tls_enabled ? 'enabled' : 'disabled'}" do
             let(:capability)      { { :foo => ["publish"] } }
-            let(:token_details)   { Ably::Realtime::Client.new(default_options).auth.request_token_sync(capability: capability) }
+            let(:token_client)    { auto_close Ably::Realtime::Client.new(default_options) }
+            let(:token_details)   { token_client.auth.request_token_sync(capability: capability) }
             let(:client_options)  { default_options.merge(token: token_details.token) }
 
             context 'and a pre-generated Token provided with the :token option' do
@@ -93,7 +94,7 @@ describe Ably::Realtime::Client, :event_machine do
           let(:auth)      { subject.auth }
 
           subject do
-            Ably::Realtime::Client.new(client_options.merge(auth_callback: Proc.new do
+            auto_close Ably::Realtime::Client.new(client_options.merge(auth_callback: Proc.new do
               @block_called = true
               auth.create_token_request_sync(client_id: client_id)
             end))

--- a/spec/acceptance/realtime/connection_failures_spec.rb
+++ b/spec/acceptance/realtime/connection_failures_spec.rb
@@ -11,7 +11,7 @@ describe Ably::Realtime::Connection, 'failures', :event_machine do
 
     let(:client_options) { default_options }
     let(:client) do
-      Ably::Realtime::Client.new(client_options)
+      auto_close Ably::Realtime::Client.new(client_options)
     end
 
     context 'authentication failure' do
@@ -281,7 +281,7 @@ describe Ably::Realtime::Connection, 'failures', :event_machine do
       let(:channel_name) { random_str }
       let(:channel) { client.channel(channel_name) }
       let(:publishing_client) do
-        Ably::Realtime::Client.new(client_options)
+        auto_close Ably::Realtime::Client.new(client_options)
       end
       let(:publishing_client_channel) { publishing_client.channel(channel_name) }
       let(:client_options) { default_options.merge(log_level: :none) }

--- a/spec/acceptance/realtime/connection_failures_spec.rb
+++ b/spec/acceptance/realtime/connection_failures_spec.rb
@@ -468,6 +468,8 @@ describe Ably::Realtime::Connection, 'failures', :event_machine do
 
       context 'when failing to resume' do
         context 'because the connection_key is not or no longer valid' do
+          let(:channel) { client.channel(random_str) }
+
           def kill_connection_transport_and_prevent_valid_resume
             connection.transport.close_connection_after_writing
             connection.configure_new '0123456789abcdef', 'wVIsgTHAB1UvXh7z-1991d8586', -1 # force the resume connection key to be invalid
@@ -509,15 +511,15 @@ describe Ably::Realtime::Connection, 'failures', :event_machine do
           end
 
           it 'emits an error on the channel and sets the error reason' do
-            client.channel(random_str).attach do |channel|
-              channel.on(:error) do |error|
-                expect(error.message).to match(/Unable to recover connection/i)
-                expect(error.code).to eql(80008)
-                expect(channel.error_reason).to eql(error)
-                stop_reactor
-              end
-
+            channel.attach do
               kill_connection_transport_and_prevent_valid_resume
+            end
+
+            channel.on(:error) do |error|
+              expect(error.message).to match(/Unable to recover connection/i)
+              expect(error.code).to eql(80008)
+              expect(channel.error_reason).to eql(error)
+              stop_reactor
             end
           end
         end
@@ -627,11 +629,11 @@ describe Ably::Realtime::Connection, 'failures', :event_machine do
 
           it 'uses a fallback host on every subsequent disconnected attempt until suspended' do
             request = 0
-            expect(EventMachine).to receive(:connect).exactly(retry_count_for_one_state).times do |host|
+            # Expect retry attempts + 1 attempt for the next state
+            expect(EventMachine).to receive(:connect).exactly(retry_count_for_one_state + 1).times do |host|
               if request == 0
                 expect(host).to eql(expected_host)
               else
-                expect(custom_hosts).to include(host)
                 fallback_hosts_used << host
               end
               request += 1
@@ -639,6 +641,7 @@ describe Ably::Realtime::Connection, 'failures', :event_machine do
             end
 
             connection.on(:suspended) do
+              fallback_hosts_used.pop # remove suspended attempt host
               expect(fallback_hosts_used.uniq).to match_array(custom_hosts)
               stop_reactor
             end

--- a/spec/acceptance/realtime/message_spec.rb
+++ b/spec/acceptance/realtime/message_spec.rb
@@ -9,12 +9,12 @@ describe 'Ably::Realtime::Channel Message', :event_machine do
     let(:default_options) { options.merge(key: api_key, environment: environment, protocol: protocol) }
     let(:client_options)  { default_options }
     let(:client) do
-      Ably::Realtime::Client.new(client_options)
+      auto_close Ably::Realtime::Client.new(client_options)
     end
     let(:channel) { client.channel(channel_name) }
 
     let(:other_client) do
-      Ably::Realtime::Client.new(client_options)
+      auto_close Ably::Realtime::Client.new(client_options)
     end
     let(:other_client_channel) { other_client.channel(channel_name) }
 
@@ -181,7 +181,7 @@ describe 'Ably::Realtime::Channel Message', :event_machine do
 
       context 'with :echo_messages option set to false' do
         let(:no_echo_client) do
-          Ably::Realtime::Client.new(default_options.merge(echo_messages: false))
+          auto_close Ably::Realtime::Client.new(default_options.merge(echo_messages: false))
         end
         let(:no_echo_channel) { no_echo_client.channel(channel_name) }
 
@@ -275,7 +275,7 @@ describe 'Ably::Realtime::Channel Message', :event_machine do
 
     context 'without suitable publishing permissions' do
       let(:restricted_client) do
-        Ably::Realtime::Client.new(options.merge(key: restricted_api_key, environment: environment, protocol: protocol, :log_level => :error))
+        auto_close Ably::Realtime::Client.new(options.merge(key: restricted_api_key, environment: environment, protocol: protocol, :log_level => :error))
       end
       let(:restricted_channel) { restricted_client.channel("cansubscribe:example") }
       let(:payload)            { 'Test message without permission to publish' }
@@ -450,7 +450,7 @@ describe 'Ably::Realtime::Channel Message', :event_machine do
       context 'subscribing with a different transport protocol' do
         let(:other_protocol) { protocol == :msgpack ? :json : :msgpack }
         let(:other_client) do
-          Ably::Realtime::Client.new(default_options.merge(protocol: other_protocol))
+          auto_close Ably::Realtime::Client.new(default_options.merge(protocol: other_protocol))
         end
 
         let(:cipher_options)            { { key: random_str(32), algorithm: 'aes', mode: 'cbc', key_length: 256 } }

--- a/spec/acceptance/realtime/message_spec.rb
+++ b/spec/acceptance/realtime/message_spec.rb
@@ -283,8 +283,7 @@ describe 'Ably::Realtime::Channel Message', :event_machine do
       it 'calls the error callback' do
         restricted_channel.attach do
           deferrable = restricted_channel.publish('test_event', payload)
-          deferrable.errback do |message, error|
-            expect(message.data).to eql(payload)
+          deferrable.errback do |error|
             expect(error.status).to eql(401)
             stop_reactor
           end

--- a/spec/acceptance/realtime/presence_history_spec.rb
+++ b/spec/acceptance/realtime/presence_history_spec.rb
@@ -7,11 +7,11 @@ describe Ably::Realtime::Presence, 'history', :event_machine do
 
     let(:channel_name)        { "persisted:#{random_str(2)}" }
 
-    let(:client_one)          { Ably::Realtime::Client.new(default_options.merge(client_id: random_str)) }
+    let(:client_one)          { auto_close Ably::Realtime::Client.new(default_options.merge(client_id: random_str)) }
     let(:channel_client_one)  { client_one.channel(channel_name) }
     let(:presence_client_one) { channel_client_one.presence }
 
-    let(:client_two)          { Ably::Realtime::Client.new(default_options.merge(client_id: random_str)) }
+    let(:client_two)          { auto_close Ably::Realtime::Client.new(default_options.merge(client_id: random_str)) }
     let(:channel_client_two)  { client_two.channel(channel_name) }
     let(:presence_client_two) { channel_client_two.presence }
 

--- a/spec/acceptance/realtime/presence_spec.rb
+++ b/spec/acceptance/realtime/presence_spec.rb
@@ -277,8 +277,7 @@ describe Ably::Realtime::Presence, :event_machine do
 
               presence_client_one.public_send(method_name, args).tap do |deferrable|
                 deferrable.callback { raise 'Should not succeed' }
-                deferrable.errback do |presence, error|
-                  expect(presence).to be_a(Ably::Realtime::Presence)
+                deferrable.errback do |error|
                   expect(error).to be_kind_of(Ably::Exceptions::BaseAblyException)
                   stop_reactor
                 end

--- a/spec/acceptance/realtime/presence_spec.rb
+++ b/spec/acceptance/realtime/presence_spec.rb
@@ -8,9 +8,9 @@ describe Ably::Realtime::Presence, :event_machine do
     let(:default_options) { { key: api_key, environment: environment, protocol: protocol } }
     let(:client_options)  { default_options }
 
-    let(:anonymous_client) { Ably::Realtime::Client.new(client_options) }
-    let(:client_one)       { Ably::Realtime::Client.new(client_options.merge(client_id: random_str)) }
-    let(:client_two)       { Ably::Realtime::Client.new(client_options.merge(client_id: random_str)) }
+    let(:anonymous_client) { auto_close Ably::Realtime::Client.new(client_options) }
+    let(:client_one)       { auto_close Ably::Realtime::Client.new(client_options.merge(client_id: random_str)) }
+    let(:client_two)       { auto_close Ably::Realtime::Client.new(client_options.merge(client_id: random_str)) }
 
     let(:channel_name)              { "presence-#{random_str(4)}" }
     let(:channel_anonymous_client)  { anonymous_client.channel(channel_name) }
@@ -72,7 +72,7 @@ describe Ably::Realtime::Presence, :event_machine do
         end
 
         context 'when :queue_messages client option is false' do
-          let(:client_one) { Ably::Realtime::Client.new(default_options.merge(queue_messages: false, client_id: random_str)) }
+          let(:client_one) { auto_close Ably::Realtime::Client.new(default_options.merge(queue_messages: false, client_id: random_str)) }
 
           context 'and connection state initialized' do
             it 'raises an exception' do
@@ -94,7 +94,7 @@ describe Ably::Realtime::Presence, :event_machine do
           end
 
           context 'and connection state disconnected' do
-            let(:client_one) { Ably::Realtime::Client.new(default_options.merge(queue_messages: false, client_id: random_str, :log_level => :error)) }
+            let(:client_one) { auto_close Ably::Realtime::Client.new(default_options.merge(queue_messages: false, client_id: random_str, :log_level => :error)) }
 
             it 'raises an exception' do
               client_one.connection.once(:connected) do
@@ -663,7 +663,7 @@ describe Ably::Realtime::Presence, :event_machine do
 
       context 'without necessary capabilities to join presence' do
         let(:restricted_client) do
-          Ably::Realtime::Client.new(default_options.merge(key: restricted_api_key, log_level: :fatal))
+          auto_close Ably::Realtime::Client.new(default_options.merge(key: restricted_api_key, log_level: :fatal))
         end
         let(:restricted_channel)  { restricted_client.channel("cansubscribe:channel") }
         let(:restricted_presence) { restricted_channel.presence }
@@ -880,7 +880,7 @@ describe Ably::Realtime::Presence, :event_machine do
 
         context 'without necessary capabilities to enter on behalf of another client' do
           let(:restricted_client) do
-            Ably::Realtime::Client.new(default_options.merge(key: restricted_api_key, log_level: :fatal))
+            auto_close Ably::Realtime::Client.new(default_options.merge(key: restricted_api_key, log_level: :fatal))
           end
           let(:restricted_channel)  { restricted_client.channel("cansubscribe:channel") }
           let(:restricted_presence) { restricted_channel.presence }
@@ -1400,7 +1400,7 @@ describe Ably::Realtime::Presence, :event_machine do
       let(:client_id)   { random_str.encode(Encoding::ASCII_8BIT) }
 
       context 'in connection set up' do
-        let(:client_one)  { Ably::Realtime::Client.new(default_options.merge(client_id: client_id)) }
+        let(:client_one)  { auto_close Ably::Realtime::Client.new(default_options.merge(client_id: client_id)) }
 
         it 'is converted into UTF_8' do
           presence_client_one.enter
@@ -1413,7 +1413,7 @@ describe Ably::Realtime::Presence, :event_machine do
       end
 
       context 'in channel options' do
-        let(:client_one)  { Ably::Realtime::Client.new(default_options) }
+        let(:client_one)  { auto_close Ably::Realtime::Client.new(default_options) }
 
         it 'is converted into UTF_8' do
           presence_client_one.enter(client_id: client_id)

--- a/spec/acceptance/realtime/stats_spec.rb
+++ b/spec/acceptance/realtime/stats_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Ably::Realtime::Client, '#stats', :event_machine do
   vary_by_protocol do
     let(:client) do
-      Ably::Realtime::Client.new(key: api_key, environment: environment, protocol: protocol)
+      auto_close Ably::Realtime::Client.new(key: api_key, environment: environment, protocol: protocol)
     end
 
     describe 'fetching stats' do

--- a/spec/acceptance/realtime/time_spec.rb
+++ b/spec/acceptance/realtime/time_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Ably::Realtime::Client, '#time', :event_machine do
   vary_by_protocol do
     let(:client) do
-      Ably::Realtime::Client.new(key: api_key, environment: environment, protocol: protocol)
+      auto_close Ably::Realtime::Client.new(key: api_key, environment: environment, protocol: protocol)
     end
 
     describe 'fetching the service time' do

--- a/spec/support/event_machine_helper.rb
+++ b/spec/support/event_machine_helper.rb
@@ -18,7 +18,7 @@ module RSpec
 
     def stop_reactor
       unless realtime_clients.empty?
-        realtime_clients.pop.tap do |client|
+        realtime_clients.shift.tap do |client|
           # Ensure close appens outside of the caller as this can cause errbacks on Deferrables
           # e.g. connection.connect { connection.close } => # Error as calling close within the connected callback
           ::EventMachine.add_timer(0.05) do

--- a/spec/support/event_machine_helper.rb
+++ b/spec/support/event_machine_helper.rb
@@ -79,9 +79,12 @@ module RSpec
     def wait_until(condition_block, &block)
       raise ArgumentError, 'Block required' unless block_given?
 
-      yield if condition_block.call
-      ::EventMachine.add_timer(0.1) do
-        wait_until condition_block, &block
+      if condition_block.call
+        yield
+      else
+        ::EventMachine.add_timer(0.1) do
+          wait_until condition_block, &block
+        end
       end
     end
   end

--- a/spec/unit/models/token_details_spec.rb
+++ b/spec/unit/models/token_details_spec.rb
@@ -70,6 +70,14 @@ describe Ably::Models::TokenDetails do
           expect(subject.expired?).to eql(false)
         end
       end
+
+      context 'when expires is not available (i.e. string tokens)' do
+        subject { Ably::Models::TokenDetails.new() }
+
+        it 'is always false' do
+          expect(subject.expired?).to eql(false)
+        end
+      end
     end
   end
 

--- a/spec/unit/modules/async_wrapper_spec.rb
+++ b/spec/unit/modules/async_wrapper_spec.rb
@@ -82,7 +82,7 @@ describe Ably::Modules::AsyncWrapper, :api_private do
             expect(result).to eql(result)
             EventMachine.add_timer(sleep_time * 2) { stop_reactor }
           end
-          deferrable.errback do |result|
+          deferrable.errback do |error|
             raise 'Errback should not have been called'
           end
         end


### PR DESCRIPTION
@paddybyers FYI, I now close all connections automatically, which unfortunately unearthed a LOT of small issues in the Ruby lib to do with the library shutting down which weirdly, before this, had very little coverage.

So far, it appears that the account limits issue is no longer a problem, see https://travis-ci.org/ably/ably-ruby.  Some tests are failing, but those are primarily known problems in realtime.  This addresses https://github.com/ably/realtime/issues/296