### PR TITLE
Output detailed log for any text failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
-env: RSPEC_RETRY=true
+env: RSPEC_RETRY=false
 language: ruby
 rvm:
 - 1.9.3

--- a/ably.gemspec
+++ b/ably.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'redcarpet'
-  spec.add_development_dependency 'rspec', '~> 3.1.0' # version lock, see config.around(:example, :event_machine) in event_machine_helper.rb
+  spec.add_development_dependency 'rspec', '~> 3.2.0' # version lock, see config.around(:example, :event_machine) in event_machine_helper.rb
   spec.add_development_dependency 'rspec-retry'
   spec.add_development_dependency 'yard'
   spec.add_development_dependency 'webmock'

--- a/spec/acceptance/realtime/channel_history_spec.rb
+++ b/spec/acceptance/realtime/channel_history_spec.rb
@@ -186,9 +186,19 @@ describe Ably::Realtime::Channel, '#history', :event_machine do
                 messages.next do |next_page_messages|
                   expect(next_page_messages.items.count).to eql(5)
                   expect(next_page_messages.items.map(&:data).uniq.first).to eql(message_before_attach)
-                  expect(next_page_messages).to be_last
 
-                  stop_reactor
+                  if next_page_messages.last?
+                    expect(next_page_messages).to be_last
+                    stop_reactor
+                  else
+                    # If previous page said there is another page it is plausible and correct that
+                    # the next page is empty and then the last, if the limit was satisfied
+                    next_page_messages.next do |empty_page|
+                      expect(empty_page.items.count).to eql(0)
+                      expect(empty_page).to be_last
+                      stop_reactor
+                    end
+                  end
                 end
               end
             end

--- a/spec/acceptance/realtime/presence_spec.rb
+++ b/spec/acceptance/realtime/presence_spec.rb
@@ -666,7 +666,7 @@ describe Ably::Realtime::Presence, :event_machine do
 
           context '#get' do
             context 'with :wait_for_sync option set to true' do
-              it 'waits until sync is complete', event_machine: 15 do
+              it 'waits until sync is complete', em_timeout: 15 do
                 enter_expected_count.times do |index|
                   presence_client_one.enter_client("client:#{index}") do |message|
                     entered << message
@@ -683,7 +683,7 @@ describe Ably::Realtime::Presence, :event_machine do
             end
 
             context 'by default' do
-              it 'it does not wait for sync', event_machine: 15 do
+              it 'it does not wait for sync', em_timeout: 15 do
                 enter_expected_count.times do |index|
                   presence_client_one.enter_client("client:#{index}") do |message|
                     entered << message

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ require 'webmock/rspec'
 require 'ably'
 
 require 'support/api_helper'
+require 'support/debug_failure_helper'
 require 'support/private_api_formatter'
 require 'support/protocol_helper'
 require 'support/random_helper'

--- a/spec/support/debug_failure_helper.rb
+++ b/spec/support/debug_failure_helper.rb
@@ -1,0 +1,16 @@
+RSpec.configure do |config|
+  config.before(:example) do
+    @log_output = []
+    %w(fatal error warn info debug).each do |method_name|
+      allow_any_instance_of(Ably::Logger).to receive(method_name.to_sym).and_wrap_original do |method, *args|
+        @log_output << "[#{method_name}] #{args[0]}"
+        method.call(*args)
+      end
+    end
+  end
+
+  config.after(:example) do |example|
+    exception = example.exception
+    puts "\n#{'-'*35}\nVerbose Ably log from test failure:\n#{'-'*35}\n#{@log_output.join("\n")}\n\n" if exception
+  end
+end

--- a/spec/support/debug_failure_helper.rb
+++ b/spec/support/debug_failure_helper.rb
@@ -3,7 +3,7 @@ RSpec.configure do |config|
     @log_output = []
     %w(fatal error warn info debug).each do |method_name|
       allow_any_instance_of(Ably::Logger).to receive(method_name.to_sym).and_wrap_original do |method, *args|
-        @log_output << "[#{method_name}] #{args[0]}"
+        @log_output << "#{Time.now.strftime('%H:%M:%S.%L')} [\e[33m#{method_name}\e[0m] #{args[0]}"
         method.call(*args)
       end
     end
@@ -11,6 +11,6 @@ RSpec.configure do |config|
 
   config.after(:example) do |example|
     exception = example.exception
-    puts "\n#{'-'*35}\nVerbose Ably log from test failure:\n#{'-'*35}\n#{@log_output.join("\n")}\n\n" if exception
+    puts "\n#{'-'*34}\n\e[36mVerbose Ably log from test failure\e[0m\n#{'-'*34}\n#{@log_output.join("\n")}\n\n" if exception
   end
 end


### PR DESCRIPTION
I have been seeing intermittent failures in the Ruby test suite in Travis, so I have now added a wrapper for the tests that collects verbose logs and only outputs the detail if the test fails.  This is going to be hugely useful in debugging issues we see in CI, at least for Ruby ayway.

FYI @SimonWoolf @paddybyers 