### PR TITLE
Some intermittent test fixes & enable tests that were blocked

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
-env: RSPEC_RETRY=true
+env: RSPEC_RETRY=false
 language: ruby
 rvm:
 - 1.9.3

--- a/ably.gemspec
+++ b/ably.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'redcarpet'
-  spec.add_development_dependency 'rspec', '~> 3.1.0' # version lock, see config.around(:example, :event_machine) in event_machine_helper.rb
+  spec.add_development_dependency 'rspec', '~> 3.2.0' # version lock, see config.around(:example, :event_machine) in event_machine_helper.rb
   spec.add_development_dependency 'rspec-retry'
   spec.add_development_dependency 'yard'
   spec.add_development_dependency 'webmock'

--- a/lib/ably/auth.rb
+++ b/lib/ably/auth.rb
@@ -616,7 +616,7 @@ module Ably
     end
 
     def has_client_id?
-      !!client_id
+      client_id && (client_id != '*')
     end
 
     def api_key_present?

--- a/lib/ably/modules/state_emitter.rb
+++ b/lib/ably/modules/state_emitter.rb
@@ -71,11 +71,11 @@ module Ably::Modules
     # @yield block is called if the state is matched immediately or once when the state is reached
     #
     # @return [void]
-    def once_or_if(target_states, options = {})
+    def once_or_if(target_states, options = {}, &block)
       raise ArgumentError, 'Block required' unless block_given?
 
       if Array(target_states).any? { |target_state| state == target_state }
-        yield
+        safe_yield block
       else
         failure_block   = options.fetch(:else, nil)
         failure_wrapper = nil

--- a/lib/ably/realtime/auth.rb
+++ b/lib/ably/realtime/auth.rb
@@ -37,7 +37,7 @@ module Ably
       include Ably::Modules::AsyncWrapper
 
       def_delegators :auth_sync, :client_id
-      def_delegators :auth_sync, :token_client_id_allowed?, :configure_client_id, :client_id_confirmed?, :can_assume_client_id?
+      def_delegators :auth_sync, :token_client_id_allowed?, :configure_client_id, :client_id_validated?, :can_assume_client_id?
       def_delegators :auth_sync, :current_token_details, :token
       def_delegators :auth_sync, :key, :key_name, :key_secret, :options, :auth_options, :token_params
       def_delegators :auth_sync, :using_basic_auth?, :using_token_auth?

--- a/lib/ably/realtime/auth.rb
+++ b/lib/ably/realtime/auth.rb
@@ -37,7 +37,8 @@ module Ably
       include Ably::Modules::AsyncWrapper
 
       def_delegators :auth_sync, :client_id
-      def_delegators :auth_sync, :token_client_id_allowed?, :configure_client_id, :client_id_validated?, :can_assume_client_id?
+      def_delegators :auth_sync, :token_client_id_allowed?, :configure_client_id, :client_id_validated?
+      def_delegators :auth_sync, :can_assume_client_id?, :has_client_id?
       def_delegators :auth_sync, :current_token_details, :token
       def_delegators :auth_sync, :key, :key_name, :key_secret, :options, :auth_options, :token_params
       def_delegators :auth_sync, :using_basic_auth?, :using_token_auth?

--- a/lib/ably/realtime/channel.rb
+++ b/lib/ably/realtime/channel.rb
@@ -351,12 +351,12 @@ module Ably
         Ably::Util::SafeDeferrable.new(logger).tap do |deferrable|
           messages.each do |message|
             message.callback do
-              return if failed
+              next if failed
               actual_deliveries += 1
               deferrable.succeed messages if actual_deliveries == expected_deliveries
             end
             message.errback do |error|
-              return if failed
+              next if failed
               failed = true
               deferrable.fail error, message
             end

--- a/lib/ably/realtime/client/incoming_message_dispatcher.rb
+++ b/lib/ably/realtime/client/incoming_message_dispatcher.rb
@@ -142,9 +142,7 @@ module Ably::Realtime
       end
 
       def process_connected_message(protocol_message)
-        if !protocol_message.connection_details.has_client_id?
-          connection.transition_state_machine :connected, reason: protocol_message.error, protocol_message: protocol_message
-        elsif client.auth.token_client_id_allowed?(protocol_message.connection_details.client_id)
+        if client.auth.token_client_id_allowed?(protocol_message.connection_details.client_id)
           client.auth.configure_client_id protocol_message.connection_details.client_id
           connection.transition_state_machine :connected, reason: protocol_message.error, protocol_message: protocol_message
         else

--- a/lib/ably/realtime/connection.rb
+++ b/lib/ably/realtime/connection.rb
@@ -386,6 +386,8 @@ module Ably
                 echo:      client.echo_messages
               )
 
+              url_params['clientId'] = client.auth.client_id if client.auth.has_client_id?
+
               if connection_resumable?
                 url_params.merge! resume: key, connection_serial: serial
                 logger.debug "Resuming connection key #{key} with serial #{serial}"

--- a/spec/acceptance/realtime/channel_history_spec.rb
+++ b/spec/acceptance/realtime/channel_history_spec.rb
@@ -186,9 +186,19 @@ describe Ably::Realtime::Channel, '#history', :event_machine do
                 messages.next do |next_page_messages|
                   expect(next_page_messages.items.count).to eql(5)
                   expect(next_page_messages.items.map(&:data).uniq.first).to eql(message_before_attach)
-                  expect(next_page_messages).to be_last
 
-                  stop_reactor
+                  if next_page_messages.last?
+                    expect(next_page_messages).to be_last
+                    stop_reactor
+                  else
+                    # If previous page said there is another page it is plausible and correct that
+                    # the next page is empty and then the last, if the limit was satisfied
+                    next_page_messages.next do |empty_page|
+                      expect(empty_page.items.count).to eql(0)
+                      expect(empty_page).to be_last
+                      stop_reactor
+                    end
+                  end
                 end
               end
             end

--- a/spec/acceptance/realtime/client_spec.rb
+++ b/spec/acceptance/realtime/client_spec.rb
@@ -133,7 +133,7 @@ describe Ably::Realtime::Client, :event_machine do
           end
 
           context 'with a wildcard client_id token' do
-            subject                 { Ably::Realtime::Client.new(client_options) }
+            subject                 { auto_close Ably::Realtime::Client.new(client_options) }
             let(:client_options)    { default_options.merge(auth_callback: Proc.new { auth_token_object }, client_id: client_id) }
             let(:rest_auth_client)  { Ably::Rest::Client.new(default_options.merge(key: api_key)) }
             let(:auth_token_object) { rest_auth_client.auth.request_token(client_id: '*') }

--- a/spec/acceptance/realtime/client_spec.rb
+++ b/spec/acceptance/realtime/client_spec.rb
@@ -141,10 +141,10 @@ describe Ably::Realtime::Client, :event_machine do
             context 'and an explicit client_id in ClientOptions' do
               let(:client_id) { random_str }
 
-              it 'allows the explicit client_id to be used for the connection' do
+              it 'allows uses the explicit client_id in the connection' do
                 connection.__incoming_protocol_msgbus__.subscribe(:protocol_message) do |protocol_message|
                   if protocol_message.action == :connected
-                    expect(protocol_message.connection_details.client_id).to be_nil
+                    expect(protocol_message.connection_details.client_id).to eql(client_id)
                     @valid_client_id = true
                   end
                 end
@@ -157,10 +157,10 @@ describe Ably::Realtime::Client, :event_machine do
             context 'and client_id omitted in ClientOptions' do
               let(:client_options) { default_options.merge(auth_callback: Proc.new { auth_token_object }) }
 
-              it 'allows omitted client_id to be used for the connection' do
+              it 'uses the token provided clientId in the connection' do
                 connection.__incoming_protocol_msgbus__.subscribe(:protocol_message) do |protocol_message|
                   if protocol_message.action == :connected
-                    expect(protocol_message.connection_details.client_id).to be_nil
+                    expect(protocol_message.connection_details.client_id).to eql('*')
                     @valid_client_id = true
                   end
                 end

--- a/spec/acceptance/realtime/connection_failures_spec.rb
+++ b/spec/acceptance/realtime/connection_failures_spec.rb
@@ -456,7 +456,6 @@ describe Ably::Realtime::Connection, 'failures', :event_machine do
           end
         end
 
-        # TODO: Review this behaviour as channels should perhaps be detached, see Wiki issues #33
         it 'emits any error received from Ably but leaves the channels attached' do
           emitted_error = nil
           channel.attach do

--- a/spec/acceptance/realtime/connection_failures_spec.rb
+++ b/spec/acceptance/realtime/connection_failures_spec.rb
@@ -300,13 +300,6 @@ describe Ably::Realtime::Connection, 'failures', :event_machine do
             connection.connect
           end
 
-          it 'calls the errback of the returned Deferrable object when first connection attempt fails' do
-            connection.connect.errback do |error|
-              expect(connection.state).to eq(:disconnected)
-              stop_reactor
-            end
-          end
-
           context 'when retry intervals are stubbed to attempt reconnection quickly' do
             let(:client_options) do
               default_options.merge(

--- a/spec/acceptance/realtime/connection_spec.rb
+++ b/spec/acceptance/realtime/connection_spec.rb
@@ -108,8 +108,6 @@ describe Ably::Realtime::Connection, :event_machine do
                 let(:ttl) { 2 }
 
                 it 'renews token every time after it expires' do
-                  skip 'Waiting on realtime issue #343 to be resolved'
-
                   started_at = Time.now.to_f
                   connected_times = 0
                   disconnected_times = 0

--- a/spec/acceptance/realtime/connection_spec.rb
+++ b/spec/acceptance/realtime/connection_spec.rb
@@ -238,7 +238,7 @@ describe Ably::Realtime::Connection, :event_machine do
                       Ably::Rest::Client.new(default_options).auth.request_token(ttl: ttl).token
                     end
                   end
-                  let(:client_options)     { default_options.merge(auth_callback: token_callback, log_level: :debug) }
+                  let(:client_options)     { default_options.merge(auth_callback: token_callback) }
                   let(:publishing_client)  { auto_close Ably::Realtime::Client.new(default_options) }
                   let(:publishing_channel) { publishing_client.channels.get(channel_name) }
                   let(:messages_received)  { [] }

--- a/spec/acceptance/realtime/connection_spec.rb
+++ b/spec/acceptance/realtime/connection_spec.rb
@@ -229,7 +229,7 @@ describe Ably::Realtime::Connection, :event_machine do
                 end
 
                 context 'connection state' do
-                  let(:ttl)           { 2 }
+                  let(:ttl)           { 4 }
                   let(:auth_requests) { [] }
                   let(:token_callback) do
                     Proc.new do
@@ -238,7 +238,7 @@ describe Ably::Realtime::Connection, :event_machine do
                       Ably::Rest::Client.new(default_options).auth.request_token(ttl: ttl).token
                     end
                   end
-                  let(:client_options)     { default_options.merge(auth_callback: token_callback) }
+                  let(:client_options)     { default_options.merge(auth_callback: token_callback, log_level: :debug) }
                   let(:publishing_client)  { auto_close Ably::Realtime::Client.new(default_options) }
                   let(:publishing_channel) { publishing_client.channels.get(channel_name) }
                   let(:messages_received)  { [] }
@@ -270,7 +270,7 @@ describe Ably::Realtime::Connection, :event_machine do
                     end
                   end
 
-                  it 'retains messages published when disconnected twice during authentication', em_timeout: 15 do
+                  it 'retains messages published when disconnected twice during authentication', em_timeout: 20 do
                     publishing_channel.attach do
                       channel.attach do
                         connection.once(:disconnected) do
@@ -299,7 +299,7 @@ describe Ably::Realtime::Connection, :event_machine do
                   end
                   let(:client_options) { default_options.merge(auth_callback: token_callback, log_level: :none) }
 
-                  it 'transitions the connectiont to the failed state' do
+                  it 'transitions the connection to the failed state' do
                     connection.once(:disconnected) do
                       connection.once(:failed) do
                         expect(connection.error_reason.code).to eql(40101)

--- a/spec/acceptance/realtime/connection_spec.rb
+++ b/spec/acceptance/realtime/connection_spec.rb
@@ -370,7 +370,7 @@ describe Ably::Realtime::Connection, :event_machine do
                 expect(client.client_id).to eql('incompatible')
                 client.connection.once(:failed) do
                   expect(client.client_id).to eql('incompatible')
-                  expect(client.connection.error_reason).to be_a(Ably::Exceptions::IncompatibleClientId)
+                  expect(client.connection.error_reason.code).to eql(40101) # Invalid clientId for credentials
                   stop_reactor
                 end
               end

--- a/spec/acceptance/realtime/connection_spec.rb
+++ b/spec/acceptance/realtime/connection_spec.rb
@@ -936,7 +936,7 @@ describe Ably::Realtime::Connection, :event_machine do
 
       it 'opens each with a unique connection#id and connection#key' do
         connection_count.times.map do
-          Ably::Realtime::Client.new(client_options)
+          auto_close Ably::Realtime::Client.new(client_options)
         end.each do |client|
           client.connection.on(:connected) do
             connection_ids  << client.connection.id

--- a/spec/acceptance/realtime/connection_spec.rb
+++ b/spec/acceptance/realtime/connection_spec.rb
@@ -380,10 +380,10 @@ describe Ably::Realtime::Connection, :event_machine do
           context 'wildcard' do
             let(:client_id) { '*' }
 
-            it 'does not configure the Client#client_id and Auth#client_id once CONNECTED' do
+            it 'configures the Client#client_id and Auth#client_id with a wildcard once CONNECTED' do
               expect(client.client_id).to be_nil
               client.connection.once(:connected) do
-                expect(client.client_id).to be_nil
+                expect(client.client_id).to eql('*')
                 stop_reactor
               end
             end

--- a/spec/acceptance/realtime/presence_spec.rb
+++ b/spec/acceptance/realtime/presence_spec.rb
@@ -666,7 +666,7 @@ describe Ably::Realtime::Presence, :event_machine do
 
           context '#get' do
             context 'with :wait_for_sync option set to true' do
-              it 'waits until sync is complete', event_machine: 15 do
+              it 'waits until sync is complete', em_timeout: 15 do
                 enter_expected_count.times do |index|
                   presence_client_one.enter_client("client:#{index}") do |message|
                     entered << message
@@ -683,7 +683,7 @@ describe Ably::Realtime::Presence, :event_machine do
             end
 
             context 'by default' do
-              it 'it does not wait for sync', event_machine: 15 do
+              it 'it does not wait for sync', em_timeout: 15 do
                 enter_expected_count.times do |index|
                   presence_client_one.enter_client("client:#{index}") do |message|
                     entered << message

--- a/spec/acceptance/realtime/presence_spec.rb
+++ b/spec/acceptance/realtime/presence_spec.rb
@@ -384,7 +384,6 @@ describe Ably::Realtime::Presence, :event_machine do
 
           context 'after authentication' do
             it 'throws an exception' do
-              skip 'Awaiting realtime issue #349 to be addressed first'
               channel.attach do
                 expect { presence_channel.public_send(method_name, 'invalid') }.to raise_error Ably::Exceptions::IncompatibleClientId
                 stop_reactor

--- a/spec/acceptance/realtime/presence_spec.rb
+++ b/spec/acceptance/realtime/presence_spec.rb
@@ -555,7 +555,10 @@ describe Ably::Realtime::Presence, :event_machine do
                 presence_anonymous_client.subscribe(:leave) do |leave_message|
                   expect(leave_message.client_id).to eql(leave_member.client_id)
                   expect(present.count).to be < enter_expected_count
-                  stop_reactor
+                  EventMachine.add_timer(1) do
+                    presence_anonymous_client.unsubscribe
+                    stop_reactor
+                  end
                 end
 
                 anonymous_client.connect do
@@ -592,7 +595,10 @@ describe Ably::Realtime::Presence, :event_machine do
                   if present.count == enter_expected_count
                     presence_anonymous_client.get do |members|
                       expect(members.find { |member| member.client_id == leave_member.client_id}.action).to eq(:present)
-                      stop_reactor
+                      EventMachine.add_timer(1) do
+                        presence_anonymous_client.unsubscribe
+                        stop_reactor
+                      end
                     end
                   end
                 end
@@ -644,7 +650,10 @@ describe Ably::Realtime::Presence, :event_machine do
                   expect(members.count).to eql(enter_expected_count - 1)
                   expect(member_left_emitted).to eql(true)
                   expect(members.map(&:client_id)).to_not include(left_client_id)
-                  stop_reactor
+                  EventMachine.add_timer(1) do
+                    presence_anonymous_client.unsubscribe
+                    stop_reactor
+                  end
                 end
 
                 channel_anonymous_client.attach do

--- a/spec/acceptance/realtime/time_spec.rb
+++ b/spec/acceptance/realtime/time_spec.rb
@@ -25,7 +25,7 @@ describe Ably::Realtime::Client, '#time', :event_machine do
 
       context 'with reconfigured HTTP timeout' do
         let(:client) do
-          Ably::Realtime::Client.new(http_request_timeout: 0.0001, key: api_key, environment: environment, protocol: protocol, log_level: :fatal)
+          auto_close Ably::Realtime::Client.new(http_request_timeout: 0.0001, key: api_key, environment: environment, protocol: protocol, log_level: :fatal)
         end
 
         it 'should raise a timeout exception' do

--- a/spec/acceptance/rest/auth_spec.rb
+++ b/spec/acceptance/rest/auth_spec.rb
@@ -1009,14 +1009,14 @@ describe Ably::Auth do
       end
     end
 
-    describe '#client_id_confirmed?' do
+    describe '#client_id_validated?' do
       let(:auth) { Ably::Rest::Client.new(default_options.merge(key: api_key)).auth }
 
       context 'when using basic auth' do
         let(:client_options) { default_options.merge(key: api_key) }
 
         it 'is false as basic auth users do not have an identity' do
-          expect(client.auth).to_not be_client_id_confirmed
+          expect(client.auth).to_not be_client_id_validated
         end
       end
 
@@ -1024,7 +1024,7 @@ describe Ably::Auth do
         let(:client_options) { default_options.merge(token: auth.request_token(client_id: 'present').token) }
 
         it 'is false as identification is not possible from an opaque token string' do
-          expect(client.auth).to_not be_client_id_confirmed
+          expect(client.auth).to_not be_client_id_validated
         end
       end
 
@@ -1033,7 +1033,7 @@ describe Ably::Auth do
           let(:client_options) { default_options.merge(token: auth.request_token(client_id: 'present')) }
 
           it 'is true' do
-            expect(client.auth).to be_client_id_confirmed
+            expect(client.auth).to be_client_id_validated
           end
         end
 
@@ -1041,7 +1041,7 @@ describe Ably::Auth do
           let(:client_options) { default_options.merge(token: auth.request_token(client_id: nil)) }
 
           it 'is true' do
-            expect(client.auth).to be_client_id_confirmed
+            expect(client.auth).to be_client_id_validated
           end
         end
 
@@ -1049,7 +1049,7 @@ describe Ably::Auth do
           let(:client_options) { default_options.merge(token: auth.request_token(client_id: '*')) }
 
           it 'is false' do
-            expect(client.auth).to_not be_client_id_confirmed
+            expect(client.auth).to be_client_id_validated
           end
         end
       end
@@ -1058,14 +1058,14 @@ describe Ably::Auth do
         let(:client_options) { default_options.merge(token: auth.create_token_request(client_id: 'present')) }
 
         it 'is not true as identification is not confirmed until authenticated' do
-          expect(client.auth).to_not be_client_id_confirmed
+          expect(client.auth).to_not be_client_id_validated
         end
 
         context 'after authentication' do
           before { client.channel('test').publish('a') }
 
           it 'is true as identification is completed during implicit authentication' do
-            expect(client.auth).to be_client_id_confirmed
+            expect(client.auth).to be_client_id_validated
           end
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ require 'webmock/rspec'
 require 'ably'
 
 require 'support/api_helper'
+require 'support/debug_failure_helper'
 require 'support/private_api_formatter'
 require 'support/protocol_helper'
 require 'support/random_helper'

--- a/spec/support/debug_failure_helper.rb
+++ b/spec/support/debug_failure_helper.rb
@@ -1,0 +1,16 @@
+RSpec.configure do |config|
+  config.before(:example) do
+    @log_output = []
+    %w(fatal error warn info debug).each do |method_name|
+      allow_any_instance_of(Ably::Logger).to receive(method_name.to_sym).and_wrap_original do |method, *args|
+        @log_output << "[#{method_name}] #{args[0]}"
+        method.call(*args)
+      end
+    end
+  end
+
+  config.after(:example) do |example|
+    exception = example.exception
+    puts "\n#{'-'*35}\nVerbose Ably log from test failure:\n#{'-'*35}\n#{@log_output.join("\n")}\n\n" if exception
+  end
+end

--- a/spec/support/debug_failure_helper.rb
+++ b/spec/support/debug_failure_helper.rb
@@ -3,7 +3,7 @@ RSpec.configure do |config|
     @log_output = []
     %w(fatal error warn info debug).each do |method_name|
       allow_any_instance_of(Ably::Logger).to receive(method_name.to_sym).and_wrap_original do |method, *args|
-        @log_output << "[#{method_name}] #{args[0]}"
+        @log_output << "#{Time.now.strftime('%H:%M:%S.%L')} [\e[33m#{method_name}\e[0m] #{args[0]}"
         method.call(*args)
       end
     end
@@ -11,6 +11,6 @@ RSpec.configure do |config|
 
   config.after(:example) do |example|
     exception = example.exception
-    puts "\n#{'-'*35}\nVerbose Ably log from test failure:\n#{'-'*35}\n#{@log_output.join("\n")}\n\n" if exception
+    puts "\n#{'-'*34}\n\e[36mVerbose Ably log from test failure\e[0m\n#{'-'*34}\n#{@log_output.join("\n")}\n\n" if exception
   end
 end


### PR DESCRIPTION
@paddybyers I have enabled all the tests in `ably-ruby` that were blocked by issues in realtime now, and so far things look good.  I still have some intermittent failures, but I will try to get to the bottom of them and provide more detail once I see some patterns.

Some notes:

* I ask for next page and expect 0-x items, see c996a5ce44e589325e73658fa255f7878d3bca56, seems to be working
* I implemented the `clientIdValidated` attribute on the `Auth` object because it was 80% implemented anyway, see https://github.com/ably/docs/pull/71 and 690caac
* Issue https://github.com/ably/realtime/issues/256 is no longer an issue
* Token issue https://github.com/ably/realtime/issues/343 is no longer an issue
* I can confirm that publishing over REST with a connection key now works as expected (publish with connection key, connection ID is added when received), see https://github.com/ably/realtime/issues/285 and 1e6ed6f
* Client ID in protocol message is working correctly, see https://github.com/ably/realtime/issues/349
* I fixed the implementation of my `Connection#connect` callback anyway, although this is not part of the 0.8 spec, see 60dbac3
* A few tests broke because presence messages arrive quicker than before, even when running against sandbox, that's a good sign!

Thought you may want to know that your fixes seem to have made a very positive impact, nice one.

cc @SimonWoolf 