### PR TITLE
Fix ruby verbose warnings

### DIFF
--- a/lib/ably/auth.rb
+++ b/lib/ably/auth.rb
@@ -457,7 +457,7 @@ module Ably
     end
 
     def split_api_key_into_key_and_secret!(options)
-      api_key_parts = options[:key].to_s.match(/(?<name>[\w_-]+\.[\w_-]+):(?<secret>[\w_-]+)/)
+      api_key_parts = options[:key].to_s.match(/(?<name>[\w-]+\.[\w-]+):(?<secret>[\w-]+)/)
       raise ArgumentError, 'key is invalid' unless api_key_parts
 
       options[:key_name]   = api_key_parts[:name].encode(Encoding::UTF_8)

--- a/lib/ably/auth.rb
+++ b/lib/ably/auth.rb
@@ -405,8 +405,13 @@ module Ably
     end
 
     private
-    attr_reader :client
-    attr_reader :token_option
+    def client
+      @client
+    end
+
+    def token_option
+      @token_option
+    end
 
     def ensure_valid_auth_attributes(attributes)
       if attributes[:timestamp]

--- a/lib/ably/auth.rb
+++ b/lib/ably/auth.rb
@@ -54,6 +54,10 @@ module Ably
         raise ArgumentError, 'Expected token_params to be a Hash'
       end
 
+      # Ensure instance variables are defined
+      @client_id = nil
+      @client_id_validated = nil
+
       ensure_valid_auth_attributes auth_options
 
       @client              = client

--- a/lib/ably/logger.rb
+++ b/lib/ably/logger.rb
@@ -37,7 +37,9 @@ module Ably
     def_delegators :logger, :fatal, :error, :warn, :info, :debug
 
     private
-    attr_reader :client
+    def client
+      @client
+    end
 
     def color(color_value, string)
       "\033[#{color_value}m#{string}\033[0m"

--- a/lib/ably/models/connection_details.rb
+++ b/lib/ably/models/connection_details.rb
@@ -28,6 +28,7 @@ module Ably::Models
     # @option attributes [Integer]   :max_frame_size        maximum size for a single frame of data sent to Ably. This restriction applies to a {Ably::Models::ProtocolMessage} sent over a realtime connection, or the total body size for a REST request
     # @option attributes [Integer]   :max_inbound_rate      maximum allowable number of requests per second from a client
     # @option attributes [Integer]   :connection_state_ttl  duration in seconds that Ably will persist the connection state when a Realtime client is abruptly disconnected
+    # @option attributes [String]    :server_id             unique identifier of the Ably server where the connection is established
     #
     def initialize(attributes = {})
       @hash_object = IdiomaticRubyWrapper(attributes.clone)
@@ -35,7 +36,7 @@ module Ably::Models
       hash.freeze
     end
 
-    %w(client_id connection_key max_message_size max_frame_size max_inbound_rate connection_state_ttl).each do |attribute|
+    %w(client_id connection_key max_message_size max_frame_size max_inbound_rate connection_state_ttl server_id).each do |attribute|
       define_method attribute do
         hash[attribute.to_sym]
       end

--- a/lib/ably/models/idiomatic_ruby_wrapper.rb
+++ b/lib/ably/models/idiomatic_ruby_wrapper.rb
@@ -150,7 +150,7 @@ module Ably::Models
     #   wrapper.as_json({ 'mixedCase': true, 'snakeCase': 1 })
     def as_json(*args)
       hash.each_with_object({}) do |key_val, new_hash|
-        key, val                 = key_val
+        key                      = key_val[0]
         mixed_case_key           = convert_to_mixed_case(key)
         wrapped_val              = self[key]
         wrapped_val              = wrapped_val.as_json(args) if wrapped_val.kind_of?(IdiomaticRubyWrapper)

--- a/lib/ably/models/message.rb
+++ b/lib/ably/models/message.rb
@@ -62,7 +62,7 @@ module Ably::Models
       ensure_utf_8 :encoding,  encoding,  allow_nil: true
     end
 
-    %w( name client_id encoding connection_id ).each do |attribute|
+    %w( name client_id encoding ).each do |attribute|
       define_method attribute do
         hash[attribute.to_sym]
       end

--- a/lib/ably/models/message.rb
+++ b/lib/ably/models/message.rb
@@ -120,7 +120,9 @@ module Ably::Models
     end
 
     private
-    attr_reader :raw_hash_object
+    def raw_hash_object
+      @raw_hash_object
+    end
 
     def protocol_message_index
       protocol_message.messages.map(&:object_id).index(self.object_id)

--- a/lib/ably/models/message_encoders/cipher.rb
+++ b/lib/ably/models/message_encoders/cipher.rb
@@ -73,11 +73,11 @@ module Ably::Models::MessageEncoders
     end
 
     def cipher_algorithm(message)
-      current_encoding_part(message).to_s[/^#{ENCODING_ID}\+([\w_-]+)$/, 1]
+      current_encoding_part(message).to_s[/^#{ENCODING_ID}\+([\w-]+)$/, 1]
     end
 
     def already_encrypted?(message)
-      message.fetch(:encoding, '').to_s.match(%r{(^|/)#{ENCODING_ID}\+([\w_-]+)($|/)})
+      message.fetch(:encoding, '').to_s.match(%r{(^|/)#{ENCODING_ID}\+([\w-]+)($|/)})
     end
   end
 end

--- a/lib/ably/models/paginated_result.rb
+++ b/lib/ably/models/paginated_result.rb
@@ -95,7 +95,33 @@ module Ably::Models
     end
 
     private
-    attr_reader :http_response, :base_url, :client, :coerce_into, :raw_body, :each_block, :make_async
+    def http_response
+      @http_response
+    end
+
+    def base_url
+      @base_url
+    end
+
+    def client
+      @client
+    end
+
+    def coerce_into
+      @coerce_into
+    end
+
+    def raw_body
+      @raw_body
+    end
+
+    def each_block
+      @each_block
+    end
+
+    def make_async
+      @make_async
+    end
 
     def coerce_items_into(items, type_string)
       items.map do |item|

--- a/lib/ably/models/presence_message.rb
+++ b/lib/ably/models/presence_message.rb
@@ -143,7 +143,9 @@ module Ably::Models
     end
 
     private
-    attr_reader :raw_hash_object
+    def raw_hash_object
+      @raw_hash_object
+    end
 
     def protocol_message_index
       protocol_message.presence.index(self)

--- a/lib/ably/models/stats.rb
+++ b/lib/ably/models/stats.rb
@@ -82,7 +82,7 @@ module Ably::Models
       def from_interval_id(interval_id)
         raise ArgumentError, 'Interval ID must be a string' unless interval_id.kind_of?(String)
 
-        format = INTERVAL_FORMAT_STRING.find { |format| expected_length(format) == interval_id.length }
+        format = INTERVAL_FORMAT_STRING.find { |fmt| expected_length(fmt) == interval_id.length }
         raise ArgumentError, 'Interval ID is an invalid length' unless format
 
         Time.strptime("#{interval_id} +0000", "#{format} %z").utc
@@ -99,7 +99,7 @@ module Ably::Models
       def granularity_from_interval_id(interval_id)
         raise ArgumentError, 'Interval ID must be a string' unless interval_id.kind_of?(String)
 
-        format = INTERVAL_FORMAT_STRING.find { |format| expected_length(format) == interval_id.length }
+        format = INTERVAL_FORMAT_STRING.find { |fmt| expected_length(fmt) == interval_id.length }
         raise ArgumentError, 'Interval ID is an invalid length' unless format
 
         GRANULARITY[INTERVAL_FORMAT_STRING.index(format)]

--- a/lib/ably/models/stats.rb
+++ b/lib/ably/models/stats.rb
@@ -195,7 +195,9 @@ module Ably::Models
     end
 
     private
-    attr_reader :raw_hash_object
+    def raw_hash_object
+      @raw_hash_object
+    end
 
     def set_hash_object(hash)
       @hash_object = IdiomaticRubyWrapper(hash.clone.freeze)

--- a/lib/ably/modules/async_wrapper.rb
+++ b/lib/ably/modules/async_wrapper.rb
@@ -42,7 +42,7 @@ module Ably::Modules
       raise ArgumentError, 'Block required' unless block_given?
 
       Ably::Util::SafeDeferrable.new(logger).tap do |deferrable|
-        deferrable.callback &success_callback if success_callback
+        deferrable.callback(&success_callback) if success_callback
 
         operation_with_exception_handling = proc do
           begin

--- a/lib/ably/modules/channels_collection.rb
+++ b/lib/ably/modules/channels_collection.rb
@@ -70,6 +70,16 @@ module Ably::Modules
     end
 
     private
-    attr_reader :client, :channel_klass, :channels
+    def client
+      @client
+    end
+
+    def channel_klass
+      @channel_klass
+    end
+
+    def channels
+      @channels
+    end
   end
 end

--- a/lib/ably/modules/enum.rb
+++ b/lib/ably/modules/enum.rb
@@ -90,7 +90,13 @@ module Ably::Modules
           end
 
           private
-          attr_reader :by_index, :by_symbol
+          def by_index
+            @by_index
+          end
+
+          def by_symbol
+            @by_symbol
+          end
 
           # Define constants for each of the Enum values
           # e.g. define_constants(:dog) creates Enum::Dog
@@ -173,7 +179,17 @@ module Ably::Modules
         end
 
         private
-        attr_reader :name, :index, :symbol
+        def name
+          @name
+        end
+
+        def index
+          @index
+        end
+
+        def symbol
+          @symbol
+        end
 
         define_values values
       end

--- a/lib/ably/modules/event_emitter.rb
+++ b/lib/ably/modules/event_emitter.rb
@@ -39,7 +39,7 @@ module Ably
 
         # Ensure @event_emitter_coerce_proc option is passed down to any classes that inherit the class with callbacks
         def inherited(subclass)
-          subclass.instance_variable_set('@event_emitter_coerce_proc', @event_emitter_coerce_proc)
+          subclass.instance_variable_set('@event_emitter_coerce_proc', @event_emitter_coerce_proc) if defined?(@event_emitter_coerce_proc)
           super
         end
       end

--- a/lib/ably/modules/event_emitter.rb
+++ b/lib/ably/modules/event_emitter.rb
@@ -90,7 +90,7 @@ module Ably
           clone.
           select do |proc_hash|
             if proc_hash[:unsafe]
-              proc_hash[:emit_proc].call *args
+              proc_hash[:emit_proc].call(*args)
             else
               safe_yield proc_hash[:emit_proc], *args
             end
@@ -133,7 +133,7 @@ module Ably
       def proc_for_block(block, options = {})
         {
           emit_proc: Proc.new do |*args|
-            block.call *args
+            block.call(*args)
             true if options[:delete_once_run]
           end,
           block: block,

--- a/lib/ably/modules/safe_deferrable.rb
+++ b/lib/ably/modules/safe_deferrable.rb
@@ -59,7 +59,7 @@ module Ably::Modules
 
     private
     def safe_deferrable_block(*args)
-      yield *args
+      yield(*args)
     rescue StandardError => e
       message = "An exception in a Deferrable callback was caught. #{e.class}: #{e.message}\n#{e.backtrace.join("\n")}"
       if defined?(:logger) && logger.respond_to?(:error)

--- a/lib/ably/modules/safe_yield.rb
+++ b/lib/ably/modules/safe_yield.rb
@@ -23,7 +23,7 @@ module Ably::Modules
       if defined?(:logger) && logger.respond_to?(:error)
         return logger.error message
       end
-    rescue StandardError => e
+    rescue StandardError
       fallback_logger.error message
     end
 

--- a/lib/ably/modules/safe_yield.rb
+++ b/lib/ably/modules/safe_yield.rb
@@ -13,7 +13,7 @@ module Ably::Modules
     private
 
     def safe_yield(block, *args)
-      block.call *args
+      block.call(*args)
     rescue StandardError => e
       message = "An exception in an external block was caught. #{e.class}: #{e.message}\n#{e.backtrace.join("\n")}"
       safe_yield_log_error message

--- a/lib/ably/modules/state_emitter.rb
+++ b/lib/ably/modules/state_emitter.rb
@@ -82,21 +82,21 @@ module Ably::Modules
 
         success_wrapper = Proc.new do
           yield
-          off &success_wrapper
-          off &failure_wrapper if failure_wrapper
+          off(&success_wrapper)
+          off(&failure_wrapper) if failure_wrapper
         end
 
         failure_wrapper = proc do |*args|
-          failure_block.call *args
-          off &success_wrapper
-          off &failure_wrapper
+          failure_block.call(*args)
+          off(&success_wrapper)
+          off(&failure_wrapper)
         end if failure_block
 
         Array(target_states).each do |target_state|
           safe_unsafe_method options[:unsafe], :once, target_state, &success_wrapper
 
           safe_unsafe_method options[:unsafe], :once_state_changed do |*args|
-            failure_wrapper.call *args unless state == target_state
+            failure_wrapper.call(*args) unless state == target_state
           end if failure_block
         end
       end
@@ -119,8 +119,8 @@ module Ably::Modules
       raise ArgumentError, 'Block required' unless block_given?
 
       once_block = proc do |*args|
-        off *self.class::STATE.map, &once_block
-        yield *args
+        off(*self.class::STATE.map, &once_block)
+        yield(*args)
       end
 
       safe_unsafe_method options[:unsafe], :once, *self.class::STATE.map, &once_block

--- a/lib/ably/modules/statesman_monkey_patch.rb
+++ b/lib/ably/modules/statesman_monkey_patch.rb
@@ -5,7 +5,7 @@ module Ably::Modules
     # This can be removed once https://github.com/gocardless/statesman/issues/95 is solved
     def before_transition(options = nil, &block)
       arrayify_transition(options) do |options_without_from_array|
-        super *options_without_from_array, &block
+        super(*options_without_from_array, &block)
       end
     end
 
@@ -13,7 +13,7 @@ module Ably::Modules
     # This can be removed once https://github.com/gocardless/statesman/issues/95 is solved
     def after_transition(options = nil, &block)
       arrayify_transition(options) do |options_without_from_array|
-        super *options_without_from_array, &block
+        super(*options_without_from_array, &block)
       end
     end
 

--- a/lib/ably/modules/uses_state_machine.rb
+++ b/lib/ably/modules/uses_state_machine.rb
@@ -59,7 +59,9 @@ module Ably::Modules
     def_delegators :state_machine, :can_transition_to?
 
     private
-    attr_reader :state_machine
+    def state_machine
+      @state_machine
+    end
 
     def_delegators :state_machine, :exception_for_state_change_to
 

--- a/lib/ably/modules/uses_state_machine.rb
+++ b/lib/ably/modules/uses_state_machine.rb
@@ -87,7 +87,7 @@ module Ably::Modules
 
     module ClassMethods
       def emits_klass
-        @emits_klass ||= if @emits_klass_name
+        @emits_klass ||= if defined?(@emits_klass_name) && @emits_klass_name
           get_const(@emits_klass_name)
         end
       end

--- a/lib/ably/realtime/auth.rb
+++ b/lib/ably/realtime/auth.rb
@@ -189,9 +189,13 @@ module Ably
       private
       # The synchronous Auth class instanced by the Rest client
       # @return [Ably::Auth]
-      attr_reader :auth_sync
+      def auth_sync
+        @auth_sync
+      end
 
-      attr_reader :client
+      def client
+        @client
+      end
     end
   end
 end

--- a/lib/ably/realtime/channel.rb
+++ b/lib/ably/realtime/channel.rb
@@ -294,7 +294,9 @@ module Ably
       private :change_state
 
       private
-      attr_reader :queue
+      def queue
+        @queue
+      end
 
       def setup_event_handlers
         __incoming_msgbus__.subscribe(:message) do |message|

--- a/lib/ably/realtime/channel.rb
+++ b/lib/ably/realtime/channel.rb
@@ -387,8 +387,8 @@ module Ably
       end
 
       def create_message(message)
-        Ably::Models::Message(message.dup).tap do |message|
-          message.encode self
+        Ably::Models::Message(message.dup).tap do |msg|
+          msg.encode self
         end
       end
 

--- a/lib/ably/realtime/channel.rb
+++ b/lib/ably/realtime/channel.rb
@@ -325,7 +325,7 @@ module Ably
           end
         end
 
-        queue.push *messages
+        queue.push(*messages)
 
         if attached?
           process_queue

--- a/lib/ably/realtime/channel/channel_manager.rb
+++ b/lib/ably/realtime/channel/channel_manager.rb
@@ -94,8 +94,14 @@ module Ably::Realtime
       end
 
       private
+      def channel
+        @channel
+      end
 
-      attr_reader :channel, :connection
+      def connection
+        @connection
+      end
+
       def_delegators :channel, :can_transition_to?
 
       # If the connection has not previously connected, connect now

--- a/lib/ably/realtime/client.rb
+++ b/lib/ably/realtime/client.rb
@@ -150,11 +150,6 @@ module Ably
         endpoint_for_host(custom_realtime_host || [environment, DOMAIN].compact.join('-'))
       end
 
-
-      def connection
-        @connection
-      end
-
       # (see Ably::Rest::Client#register_encoder)
       def register_encoder(encoder)
         rest_client.register_encoder encoder

--- a/lib/ably/realtime/client.rb
+++ b/lib/ably/realtime/client.rb
@@ -96,7 +96,7 @@ module Ably
         @auto_connect          = @rest_client.options.fetch(:auto_connect, true) == false ? false : true
         @recover               = @rest_client.options[:recover]
 
-        raise ArgumentError, "Recovery key is invalid" if @recover && !@recover.match(Connection::RECOVER_REGEX)
+        raise ArgumentError, "Recovery key '#{recover}' is invalid" if recover && !recover.match(Connection::RECOVER_REGEX)
       end
 
       # Return a {Ably::Realtime::Channel Realtime Channel} for the given name

--- a/lib/ably/realtime/client.rb
+++ b/lib/ably/realtime/client.rb
@@ -171,7 +171,7 @@ module Ably
       # @return [URI::Generic] Fallback endpoint used to connect to the realtime Ably service. Note, after each connection attempt, a new random {Ably::FALLBACK_HOSTS fallback host} is used
       # @api private
       def fallback_endpoint
-        unless @fallback_endpoints
+        unless defined?(@fallback_endpoints) && @fallback_endpoints
           @fallback_endpoints = Ably::FALLBACK_HOSTS.shuffle.map { |fallback_host| endpoint_for_host(fallback_host) }
         end
 

--- a/lib/ably/realtime/client.rb
+++ b/lib/ably/realtime/client.rb
@@ -90,11 +90,11 @@ module Ably
         @auth                  = Ably::Realtime::Auth.new(self)
         @channels              = Ably::Realtime::Channels.new(self)
         @connection            = Ably::Realtime::Connection.new(self, options)
-        @echo_messages         = @rest_client.options.fetch(:echo_messages, true) == false ? false : true
-        @queue_messages        = @rest_client.options.fetch(:queue_messages, true) == false ? false : true
-        @custom_realtime_host  = @rest_client.options[:realtime_host] || @rest_client.options[:ws_host]
-        @auto_connect          = @rest_client.options.fetch(:auto_connect, true) == false ? false : true
-        @recover               = @rest_client.options[:recover]
+        @echo_messages         = rest_client.options.fetch(:echo_messages, true) == false ? false : true
+        @queue_messages        = rest_client.options.fetch(:queue_messages, true) == false ? false : true
+        @custom_realtime_host  = rest_client.options[:realtime_host] || rest_client.options[:ws_host]
+        @auto_connect          = rest_client.options.fetch(:auto_connect, true) == false ? false : true
+        @recover               = rest_client.options[:recover]
 
         raise ArgumentError, "Recovery key '#{recover}' is invalid" if recover && !recover.match(Connection::RECOVER_REGEX)
       end

--- a/lib/ably/realtime/client/incoming_message_dispatcher.rb
+++ b/lib/ably/realtime/client/incoming_message_dispatcher.rb
@@ -201,7 +201,7 @@ module Ably::Realtime
 
       def subscribe_to_incoming_protocol_messages
         connection.__incoming_protocol_msgbus__.subscribe(:protocol_message) do |*args|
-          dispatch_protocol_message *args
+          dispatch_protocol_message(*args)
         end
       end
     end

--- a/lib/ably/realtime/client/incoming_message_dispatcher.rb
+++ b/lib/ably/realtime/client/incoming_message_dispatcher.rb
@@ -150,6 +150,7 @@ module Ably::Realtime
       def process_connected_message(protocol_message)
         if client.auth.token_client_id_allowed?(protocol_message.connection_details.client_id)
           client.auth.configure_client_id protocol_message.connection_details.client_id
+          client.connection.set_connection_details protocol_message.connection_details
           connection.transition_state_machine :connected, reason: protocol_message.error, protocol_message: protocol_message
         else
           reason = Ably::Exceptions::IncompatibleClientId.new("Client ID '#{protocol_message.connection_details.client_id}' specified by the server is incompatible with the library's configured client ID '#{client.client_id}'", 400, 40012)

--- a/lib/ably/realtime/client/incoming_message_dispatcher.rb
+++ b/lib/ably/realtime/client/incoming_message_dispatcher.rb
@@ -13,7 +13,13 @@ module Ably::Realtime
       end
 
       private
-      attr_reader :client, :connection
+      def client
+        @client
+      end
+
+      def connection
+        @connection
+      end
 
       def channels
         client.channels

--- a/lib/ably/realtime/client/outgoing_message_dispatcher.rb
+++ b/lib/ably/realtime/client/outgoing_message_dispatcher.rb
@@ -17,7 +17,13 @@ module Ably::Realtime
       end
 
       private
-      attr_reader :client, :connection
+      def client
+        @client
+      end
+
+      def connection
+        @connection
+      end
 
       def can_send_messages?
         connection.connected? || connection.closing?

--- a/lib/ably/realtime/connection.rb
+++ b/lib/ably/realtime/connection.rb
@@ -178,12 +178,12 @@ module Ably
 
           once(:connected) do
             deferrable.succeed
-            off &fail_callback
+            off(&fail_callback)
           end
 
           once(:failed, :closed, :closing) do
             deferrable.fail
-            off &succeed_callback
+            off(&succeed_callback)
           end
         end
       end

--- a/lib/ably/realtime/connection.rb
+++ b/lib/ably/realtime/connection.rb
@@ -356,10 +356,10 @@ module Ably
       # @api private
       def send_protocol_message(protocol_message)
         add_message_serial_if_ack_required_to(protocol_message) do
-          Ably::Models::ProtocolMessage.new(protocol_message, logger: logger).tap do |protocol_message|
-            add_message_to_outgoing_queue protocol_message
-            notify_message_dispatcher_of_new_message protocol_message
-            logger.debug("Connection: Prot msg queued =>: #{protocol_message.action} #{protocol_message}")
+          Ably::Models::ProtocolMessage.new(protocol_message, logger: logger).tap do |message|
+            add_message_to_outgoing_queue message
+            notify_message_dispatcher_of_new_message message
+            logger.debug("Connection: Prot msg queued =>: #{message.action} #{message}")
           end
         end
       end

--- a/lib/ably/realtime/connection.rb
+++ b/lib/ably/realtime/connection.rb
@@ -84,6 +84,10 @@ module Ably
       # @return [Ably::Models::ErrorInfo,Ably::Exceptions::BaseAblyException]
       attr_reader :error_reason
 
+      # Connection details of the currently established connection
+      # @return [Ably::Models::ConnectionDetails]
+      attr_reader :details
+
       # {Ably::Realtime::Client} associated with this connection
       # @return [Ably::Realtime::Client]
       attr_reader :client
@@ -435,6 +439,11 @@ module Ably
       # @api private
       def clear_error_reason
         @error_reason = nil
+      end
+
+      # @api private
+      def set_connection_details(connection_details)
+        @details = connection_details
       end
 
       # Executes registered callbacks for a successful connection resume event

--- a/lib/ably/realtime/connection.rb
+++ b/lib/ably/realtime/connection.rb
@@ -476,7 +476,9 @@ module Ably
       # A connection serial guarantees the server has received the message and is thus used for connection
       # recovery and resumes.
       # @return [Integer] starting at -1 indicating no messages sent, 0 when the first message is sent
-      attr_reader :client_serial
+      def client_serial
+        @client_serial
+      end
 
       def resume_callbacks
         @resume_callbacks ||= []

--- a/lib/ably/realtime/connection.rb
+++ b/lib/ably/realtime/connection.rb
@@ -58,7 +58,7 @@ module Ably
       ensure_state_machine_emits 'Ably::Models::ConnectionStateChange'
 
       # Expected format for a connection recover key
-      RECOVER_REGEX = /^(?<recover>[\w-]+):(?<connection_serial>\-?\w+)$/
+      RECOVER_REGEX = /^(?<recover>[\w!-]+):(?<connection_serial>\-?\w+)$/
 
       # Defaults for automatic connection recovery and timeouts
       DEFAULTS = {

--- a/lib/ably/realtime/connection/connection_manager.rb
+++ b/lib/ably/realtime/connection/connection_manager.rb
@@ -215,11 +215,15 @@ module Ably::Realtime
       end
 
       private
-      attr_reader :connection
+      def connection
+        @connection
+      end
 
       # Timers used to manage connection state, for internal use by the client library
       # @return [Hash]
-      attr_reader :timers
+      def timers
+        @timers
+      end
 
       def transport
         connection.transport

--- a/lib/ably/realtime/connection/connection_manager.rb
+++ b/lib/ably/realtime/connection/connection_manager.rb
@@ -58,7 +58,7 @@ module Ably::Realtime
         end
 
         logger.debug "ConnectionManager: Setting up automatic connection timeout timer for #{realtime_request_timeout}s"
-        create_timeout_timer_whilst_in_state(:connect, realtime_request_timeout) do
+        create_timeout_timer_whilst_in_state(:connecting, realtime_request_timeout) do
           connection_opening_failed Ably::Exceptions::ConnectionTimeout.new("Connection to Ably timed out after #{realtime_request_timeout}s", nil, 80014)
         end
       end
@@ -123,7 +123,7 @@ module Ably::Realtime
       def close_connection
         connection.send_protocol_message(action: Ably::Models::ProtocolMessage::ACTION.Close)
 
-        create_timeout_timer_whilst_in_state(:close, realtime_request_timeout) do
+        create_timeout_timer_whilst_in_state(:closing, realtime_request_timeout) do
           force_close_connection if connection.closing?
         end
       end

--- a/lib/ably/realtime/connection/connection_manager.rb
+++ b/lib/ably/realtime/connection/connection_manager.rb
@@ -16,8 +16,9 @@ module Ably::Realtime
       }
 
       def initialize(connection)
-        @connection = connection
-        @timers     = Hash.new { |hash, key| hash[key] = [] }
+        @connection     = connection
+        @timers         = Hash.new { |hash, key| hash[key] = [] }
+        @renewing_token = false
 
         connection.unsafe_on(:closed) do
           connection.reset_resume_info

--- a/lib/ably/realtime/connection/websocket_transport.rb
+++ b/lib/ably/realtime/connection/websocket_transport.rb
@@ -98,11 +98,20 @@ module Ably::Realtime
       end
 
       private
-      attr_reader :connection, :driver, :reason_closed
+      def driver
+        @driver
+      end
+
+      def connection
+        @connection
+      end
+
+      def reason_closed
+        @reason_closed
+      end
 
       # Send object down the WebSocket driver connection as a serialized string/byte array based on protocol
       # @param [Object] object to serialize and send to the WebSocket driver
-      # @api public
       def send_object(object)
         case client.protocol
         when :json

--- a/lib/ably/realtime/connection/websocket_transport.rb
+++ b/lib/ably/realtime/connection/websocket_transport.rb
@@ -122,7 +122,7 @@ module Ably::Realtime
       end
 
       def clear_timer
-        if @timer
+        if defined?(@timer) && @timer
           @timer.cancel
           @timer = nil
         end

--- a/lib/ably/realtime/presence.rb
+++ b/lib/ably/realtime/presence.rb
@@ -250,11 +250,11 @@ module Ably::Realtime
       ensure_channel_attached(deferrable) do
         members.get(options).tap do |members_map_deferrable|
           members_map_deferrable.callback do |*args|
-            safe_yield block, *args if block_given?
-            deferrable.succeed *args
+            safe_yield(block, *args) if block_given?
+            deferrable.succeed(*args)
           end
           members_map_deferrable.errback do |*args|
-            deferrable.fail *args
+            deferrable.fail(*args)
           end
         end
       end
@@ -426,14 +426,14 @@ module Ably::Realtime
     end
 
     def deferrable_succeed(deferrable, *args, &block)
-      safe_yield block, self, *args if block_given?
+      safe_yield(block, self, *args) if block_given?
       EventMachine.next_tick { deferrable.succeed self, *args } # allow callback to be added to the returned Deferrable before calling succeed
       deferrable
     end
 
     def deferrable_fail(deferrable, *args, &block)
-      safe_yield block, *args if block_given?
-      EventMachine.next_tick { deferrable.fail *args } # allow errback to be added to the returned Deferrable
+      safe_yield(block, *args) if block_given?
+      EventMachine.next_tick { deferrable.fail(*args) } # allow errback to be added to the returned Deferrable
       deferrable
     end
 

--- a/lib/ably/realtime/presence/members_map.rb
+++ b/lib/ably/realtime/presence/members_map.rb
@@ -131,7 +131,21 @@ module Ably::Realtime
       end
 
       private
-      attr_reader :members, :sync_serial, :presence, :absent_member_cleanup_queue
+      def members
+        @members
+      end
+
+      def sync_serial
+        @sync_serial
+      end
+
+      def presence
+        @presence
+      end
+
+      def absent_member_cleanup_queue
+        @absent_member_cleanup_queue
+      end
 
       def channel
         presence.channel

--- a/lib/ably/realtime/presence/members_map.rb
+++ b/lib/ably/realtime/presence/members_map.rb
@@ -99,12 +99,12 @@ module Ably::Realtime
           end
 
           reset_callbacks = proc do
-            off &in_sync_callback
-            off &failed_callback
-            channel.off &failed_callback
+            off(&in_sync_callback)
+            off(&failed_callback)
+            channel.off(&failed_callback)
           end
 
-          once :in_sync, &in_sync_callback
+          once(:in_sync, &in_sync_callback)
 
           once(:failed, &failed_callback)
           channel.unsafe_once(:detaching, :detached, :failed) do |error_reason|
@@ -170,9 +170,9 @@ module Ably::Realtime
         end
 
         resume_sync_proc = method(:resume_sync).to_proc
-        connection.on_resume &resume_sync_proc
+        connection.on_resume(&resume_sync_proc)
         once(:in_sync, :failed) do
-          connection.off_resume &resume_sync_proc
+          connection.off_resume(&resume_sync_proc)
         end
 
         once(:in_sync) do

--- a/lib/ably/rest/channel.rb
+++ b/lib/ably/rest/channel.rb
@@ -65,15 +65,15 @@ module Ably
         end
 
         payload = messages.map do |message|
-          Ably::Models::Message(message.dup).tap do |message|
-            message.encode self
+          Ably::Models::Message(message.dup).tap do |msg|
+            msg.encode self
 
-            next if message.client_id.nil?
-            if message.client_id == '*'
+            next if msg.client_id.nil?
+            if msg.client_id == '*'
               raise Ably::Exceptions::IncompatibleClientId.new('Wildcard client_id is reserved and cannot be used when publishing messages', 400, 40012)
             end
-            unless client.auth.can_assume_client_id?(message.client_id)
-              raise Ably::Exceptions::IncompatibleClientId.new("Cannot publish with client_id '#{message.client_id}' as it is incompatible with the current configured client_id '#{client.client_id}'", 400, 40012)
+            unless client.auth.can_assume_client_id?(msg.client_id)
+              raise Ably::Exceptions::IncompatibleClientId.new("Cannot publish with client_id '#{msg.client_id}' as it is incompatible with the current configured client_id '#{client.client_id}'", 400, 40012)
             end
           end.as_json
         end
@@ -111,8 +111,8 @@ module Ably
         response = client.get(url, options)
 
         Ably::Models::PaginatedResult.new(response, url, client, paginated_options) do |message|
-          message.tap do |message|
-            decode_message message
+          message.tap do |msg|
+            decode_message msg
           end
         end
       end

--- a/lib/ably/rest/client.rb
+++ b/lib/ably/rest/client.rb
@@ -315,7 +315,7 @@ module Ably
       #
       # @api private
       def fallback_connection
-        unless @fallback_connections
+        unless defined?(@fallback_connections) && @fallback_connections
           @fallback_connections = Ably::FALLBACK_HOSTS.shuffle.map { |host| Faraday.new(endpoint_for_host(host).to_s, connection_options) }
         end
         @fallback_index ||= 0

--- a/lib/ably/rest/middleware/exceptions.rb
+++ b/lib/ably/rest/middleware/exceptions.rb
@@ -7,6 +7,8 @@ module Ably
       # HTTP exceptions raised by Ably due to an error status code
       # Ably returns JSON/Msgpack error codes and messages so include this if possible in the exception messages
       class Exceptions < Faraday::Response::Middleware
+        TOKEN_EXPIRED_CODE = 40140..40149
+
         def on_complete(env)
           if env.status >= 400
             error_status_code = env.status
@@ -30,7 +32,7 @@ module Ably
 
             if env.status >= 500
               raise Ably::Exceptions::ServerError.new(message, error_status_code, error_code)
-            elsif env.status == 401 && error_code == 40140
+            elsif env.status == 401 && TOKEN_EXPIRED_CODE.include?(error_code)
               raise Ably::Exceptions::TokenExpired.new(message, error_status_code, error_code)
             else
               raise Ably::Exceptions::InvalidRequest.new(message, error_status_code, error_code)

--- a/lib/ably/rest/presence.rb
+++ b/lib/ably/rest/presence.rb
@@ -40,8 +40,8 @@ module Ably
         response = client.get(base_path, options)
 
         Ably::Models::PaginatedResult.new(response, base_path, client, paginated_options) do |presence_message|
-          presence_message.tap do |presence_message|
-            decode_message presence_message
+          presence_message.tap do |message|
+            decode_message message
           end
         end
       end
@@ -74,8 +74,8 @@ module Ably
         response = client.get(url, options)
 
         Ably::Models::PaginatedResult.new(response, url, client, paginated_options) do |presence_message|
-          presence_message.tap do |presence_message|
-            decode_message presence_message
+          presence_message.tap do |message|
+            decode_message message
           end
         end
       end

--- a/spec/acceptance/realtime/channel_history_spec.rb
+++ b/spec/acceptance/realtime/channel_history_spec.rb
@@ -19,7 +19,7 @@ describe Ably::Realtime::Channel, '#history', :event_machine do
     let(:options)      { { :protocol => :json } }
 
     it 'returns a SafeDeferrable that catches exceptions in callbacks and logs them' do
-      channel.publish('event', payload) do |message|
+      channel.publish('event', payload) do
         history = channel.history
         expect(history).to be_a(Ably::Util::SafeDeferrable)
         history.callback do |page|
@@ -32,7 +32,7 @@ describe Ably::Realtime::Channel, '#history', :event_machine do
 
     context 'with a single client publishing and receiving' do
       it 'retrieves realtime history' do
-        channel.publish('event', payload) do |message|
+        channel.publish('event', payload) do
           channel.history do |page|
             expect(page.items.length).to eql(1)
             expect(page.items[0].data).to eql(payload)
@@ -44,8 +44,8 @@ describe Ably::Realtime::Channel, '#history', :event_machine do
 
     context 'with two clients publishing messages on the same channel' do
       it 'retrieves realtime history on both channels' do
-        channel.publish('event', payload) do |message|
-          channel2.publish('event', payload) do |message|
+        channel.publish('event', payload) do
+          channel2.publish('event', payload) do
             channel.history do |page|
               expect(page.items.length).to eql(2)
               expect(page.items.map(&:data).uniq).to eql([payload])

--- a/spec/acceptance/realtime/connection_failures_spec.rb
+++ b/spec/acceptance/realtime/connection_failures_spec.rb
@@ -481,8 +481,6 @@ describe Ably::Realtime::Connection, 'failures', :event_machine do
         end
 
         it 'retains channel subscription state' do
-          messages_received = false
-
           channel.subscribe('event') do |message|
             expect(message.data).to eql('message')
             stop_reactor

--- a/spec/acceptance/realtime/connection_failures_spec.rb
+++ b/spec/acceptance/realtime/connection_failures_spec.rb
@@ -710,6 +710,7 @@ describe Ably::Realtime::Connection, 'failures', :event_machine do
         context 'when the Internet is up' do
           before do
             allow(connection).to receive(:internet_up?).and_yield(true)
+            @suspended = 0
           end
 
           it 'uses a fallback host on every subsequent disconnected attempt until suspended' do
@@ -738,14 +739,13 @@ describe Ably::Realtime::Connection, 'failures', :event_machine do
                 expect(host).to eql(expected_host)
               else
                 expect(custom_hosts).to include(host)
-                fallback_hosts_used << host if @suspended
+                fallback_hosts_used << host if @suspended > 0
               end
               request += 1
               raise EventMachine::ConnectionError
             end
 
             connection.on(:suspended) do
-              @suspended ||= 0
               @suspended += 1
 
               if @suspended > 3

--- a/spec/acceptance/realtime/connection_spec.rb
+++ b/spec/acceptance/realtime/connection_spec.rb
@@ -141,7 +141,7 @@ describe Ably::Realtime::Connection, :event_machine do
                   started_at = Time.now.to_f
                   connection.once(:disconnected) do
                     connection.once(:disconnected) do |connection_state_change|
-                      expect(connection_state_change.reason.code).to eql(40140) # token expired
+                      expect(connection_state_change.reason.code).to eql(40142) # token expired
                       expect(Time.now.to_f - started_at).to be < 1000
                       expect(auth_requests.count).to eql(2)
                       stop_reactor
@@ -156,7 +156,7 @@ describe Ably::Realtime::Connection, :event_machine do
                     started_at = Time.now.to_f
                     disconnect_count = 0
                     connection.on(:disconnected) do |connection_state_change|
-                      expect(connection_state_change.reason.code).to eql(40140) # token expired
+                      expect(connection_state_change.reason.code).to eql(40142) # token expired
                       disconnect_count += 1
                       if disconnect_count == 6
                         expect(Time.now.to_f - started_at).to be > 4 * 0.5 # at least 4 0.5 second pauses should have happened
@@ -207,7 +207,7 @@ describe Ably::Realtime::Connection, :event_machine do
                       expect(original_token).to_not be_expired
                       started_at = Time.now
                       connection.once(:disconnected) do |connection_state_change|
-                        expect(connection_state_change.reason.code).to eq(40140) # Token expired
+                        expect(connection_state_change.reason.code).to eq(40142) # Token expired
 
                         # Token has expired, so now ensure it is not used again
                         stub_const 'Ably::Models::TokenDetails::TOKEN_EXPIRY_BUFFER', original_token_expiry_buffer
@@ -333,7 +333,7 @@ describe Ably::Realtime::Connection, :event_machine do
                   expect(expired_token_details).to be_expired
                   connection.once(:connected) { raise 'Connection should never connect as token has expired' }
                   connection.once(:failed) do
-                    expect(client.connection.error_reason.code).to eql(40140)
+                    expect(client.connection.error_reason.code).to eql(40142)
                     stop_reactor
                   end
                 end
@@ -813,7 +813,8 @@ describe Ably::Realtime::Connection, :event_machine do
           log_level:                  :none,
           disconnected_retry_timeout: 0.1,
           suspended_retry_timeout:    0.1,
-          connection_state_ttl:       0.2
+          connection_state_ttl:       0.2,
+          realtime_request_timeout:   5
         )
       end
 

--- a/spec/acceptance/realtime/connection_spec.rb
+++ b/spec/acceptance/realtime/connection_spec.rb
@@ -889,7 +889,8 @@ describe Ably::Realtime::Connection, :event_machine do
 
       context "opening a new connection using a recently disconnected connection's #recovery_key" do
         context 'connection#id and connection#key after recovery' do
-          it 'remains the same' do
+          it 'remains the same for id and party for key' do
+            connection_key_consistent_part_regex = /.*?!(\w{5,})-/
             previous_connection_id  = nil
             previous_connection_key = nil
 
@@ -902,8 +903,9 @@ describe Ably::Realtime::Connection, :event_machine do
             connection.once(:failed) do
               recover_client = auto_close Ably::Realtime::Client.new(default_options.merge(recover: client.connection.recovery_key))
               recover_client.connection.on(:connected) do
-                expect(recover_client.connection.key[/^\w{5,}-/, 0]).to_not be_nil
-                expect(recover_client.connection.key[/^\w{5,}-/, 0]).to eql(previous_connection_key[/^\w{5,}-/, 0])
+                expect(recover_client.connection.key[connection_key_consistent_part_regex, 1]).to_not be_nil
+                expect(recover_client.connection.key[connection_key_consistent_part_regex, 1]).to eql(
+                  previous_connection_key[connection_key_consistent_part_regex, 1])
                 expect(recover_client.connection.id).to eql(previous_connection_id)
                 stop_reactor
               end

--- a/spec/acceptance/realtime/presence_spec.rb
+++ b/spec/acceptance/realtime/presence_spec.rb
@@ -1484,8 +1484,8 @@ describe Ably::Realtime::Presence, :event_machine do
         it 'removes the callback for all presence events' do
           when_all(channel_client_one.attach, channel_client_two.attach) do
             subscribe_callback = proc { raise 'Should not be called' }
-            presence_client_two.subscribe &subscribe_callback
-            presence_client_two.unsubscribe &subscribe_callback
+            presence_client_two.subscribe(&subscribe_callback)
+            presence_client_two.unsubscribe(&subscribe_callback)
 
             presence_client_one.enter
             presence_client_one.update

--- a/spec/acceptance/realtime/presence_spec.rb
+++ b/spec/acceptance/realtime/presence_spec.rb
@@ -679,14 +679,16 @@ describe Ably::Realtime::Presence, :event_machine do
             context 'with :wait_for_sync option set to true' do
               it 'waits until sync is complete', em_timeout: 15 do
                 enter_expected_count.times do |index|
-                  presence_client_one.enter_client("client:#{index}") do |message|
-                    entered << message
-                    next unless entered.count == enter_expected_count
+                  EventMachine.add_timer(index / 10) do
+                    presence_client_one.enter_client("client:#{index}") do |message|
+                      entered << message
+                      next unless entered.count == enter_expected_count
 
-                    presence_anonymous_client.get(wait_for_sync: true) do |members|
-                      expect(members.map(&:client_id).uniq.count).to eql(enter_expected_count)
-                      expect(members.count).to eql(enter_expected_count)
-                      stop_reactor
+                      presence_anonymous_client.get(wait_for_sync: true) do |members|
+                        expect(members.map(&:client_id).uniq.count).to eql(enter_expected_count)
+                        expect(members.count).to eql(enter_expected_count)
+                        stop_reactor
+                      end
                     end
                   end
                 end
@@ -696,15 +698,17 @@ describe Ably::Realtime::Presence, :event_machine do
             context 'by default' do
               it 'it does not wait for sync', em_timeout: 15 do
                 enter_expected_count.times do |index|
-                  presence_client_one.enter_client("client:#{index}") do |message|
-                    entered << message
-                    next unless entered.count == enter_expected_count
+                  EventMachine.add_timer(index / 10) do
+                    presence_client_one.enter_client("client:#{index}") do |message|
+                      entered << message
+                      next unless entered.count == enter_expected_count
 
-                    channel_anonymous_client.attach do
-                      presence_anonymous_client.get do |members|
-                        expect(presence_anonymous_client.members).to_not be_in_sync
-                        expect(members.count).to eql(0)
-                        stop_reactor
+                      channel_anonymous_client.attach do
+                        presence_anonymous_client.get do |members|
+                          expect(presence_anonymous_client.members).to_not be_in_sync
+                          expect(members.count).to eql(0)
+                          stop_reactor
+                        end
                       end
                     end
                   end
@@ -1228,7 +1232,7 @@ describe Ably::Realtime::Presence, :event_machine do
         end
       end
 
-      context 'during a sync' do
+      context 'during a sync', em_timeout: 30 do
         let(:pages)               { 2 }
         let(:members_per_page)    { 100 }
         let(:sync_pages_received) { [] }
@@ -1237,7 +1241,15 @@ describe Ably::Realtime::Presence, :event_machine do
 
         def connect_members_deferrables
           (members_per_page * pages + 1).times.map do |index|
-            presence_client_one.enter_client("client:#{index}")
+            # rate limit to 10 per second
+            EventMachine::DefaultDeferrable.new.tap do |deferrable|
+              EventMachine.add_timer(index / 10) do
+                presence_client_one.enter_client("client:#{index}").tap do |enter_deferrable|
+                  enter_deferrable.callback { |*args| deferrable.succeed *args }
+                  enter_deferrable.errback { |*args| deferrable.fail *args }
+                end
+              end
+            end
           end
         end
 

--- a/spec/acceptance/realtime/presence_spec.rb
+++ b/spec/acceptance/realtime/presence_spec.rb
@@ -1331,9 +1331,9 @@ describe Ably::Realtime::Presence, :event_machine do
             expect(members.count).to eq(1)
             expect(members.first.connection_id).to eql(client_one.connection.id)
 
-            presence_client_one.get(connection_id: client_two.connection.id) do |members|
-              expect(members.count).to eq(1)
-              expect(members.first.connection_id).to eql(client_two.connection.id)
+            presence_client_one.get(connection_id: client_two.connection.id) do |members_two|
+              expect(members_two.count).to eq(1)
+              expect(members_two.first.connection_id).to eql(client_two.connection.id)
               stop_reactor
             end
           end
@@ -1354,10 +1354,10 @@ describe Ably::Realtime::Presence, :event_machine do
             expect(members.first.client_id).to eql(client_one_id)
             expect(members.first.connection_id).to eql(client_one.connection.id)
 
-            presence_client_one.get(client_id: client_two_id) do |members|
-              expect(members.count).to eq(1)
-              expect(members.first.client_id).to eql(client_two_id)
-              expect(members.first.connection_id).to eql(client_two.connection.id)
+            presence_client_one.get(client_id: client_two_id) do |members_two|
+              expect(members_two.count).to eq(1)
+              expect(members_two.first.client_id).to eql(client_two_id)
+              expect(members_two.first.connection_id).to eql(client_two.connection.id)
               stop_reactor
             end
           end

--- a/spec/acceptance/rest/auth_spec.rb
+++ b/spec/acceptance/rest/auth_spec.rb
@@ -689,12 +689,12 @@ describe Ably::Auth do
             stub_const 'Ably::Models::TokenDetails::TOKEN_EXPIRY_BUFFER', 0
             old_token_defaults = Ably::Auth::TOKEN_DEFAULTS
             stub_const 'Ably::Auth::TOKEN_DEFAULTS', old_token_defaults.merge(renew_token_buffer: 0)
+            @block_called = 0
           end
 
           let(:token_client)   { Ably::Rest::Client.new(default_options.merge(key: api_key, token_params: { ttl: 3 })) }
           let(:client_options) {
             default_options.merge(token: token_client.auth.request_token.token, auth_callback: Proc.new do
-              @block_called ||= 0
               @block_called += 1
               token_client.auth.create_token_request
             end)

--- a/spec/acceptance/rest/base_spec.rb
+++ b/spec/acceptance/rest/base_spec.rb
@@ -130,7 +130,7 @@ describe Ably::Rest do
           if [1, 3].include?(@publish_attempts)
             { status: 201, :body => '[]', :headers => { 'Content-Type' => 'application/json' } }
           else
-            raise Ably::Exceptions::TokenExpired.new('Authentication failure', 401, 40140)
+            raise Ably::Exceptions::TokenExpired.new('Authentication failure', 401, 40142)
           end
         end
       end

--- a/spec/shared/safe_deferrable_behaviour.rb
+++ b/spec/shared/safe_deferrable_behaviour.rb
@@ -16,7 +16,7 @@ shared_examples 'a safe Deferrable' do
       subject.errback do |*args|
         expect(args).to eql(arguments)
       end
-      subject.fail *arguments
+      subject.fail(*arguments)
     end
 
     it 'catches exceptions in the callback and logs the error to the logger' do
@@ -34,7 +34,7 @@ shared_examples 'a safe Deferrable' do
         subject.errback  { errback_calls << true }
         subject.callback { success_calls << true }
       end
-      subject.fail *arguments
+      subject.fail(*arguments)
       expect(errback_calls.count).to eql(3)
       expect(success_calls.count).to eql(0)
     end
@@ -45,7 +45,7 @@ shared_examples 'a safe Deferrable' do
       subject.callback do |*args|
         expect(args).to eql(arguments)
       end
-      subject.succeed *arguments
+      subject.succeed(*arguments)
     end
 
     it 'catches exceptions in the callback and logs the error to the logger' do
@@ -63,7 +63,7 @@ shared_examples 'a safe Deferrable' do
         subject.errback  { errback_calls << true }
         subject.callback { success_calls << true }
       end
-      subject.succeed *arguments
+      subject.succeed(*arguments)
       expect(success_calls.count).to eql(3)
       expect(errback_calls.count).to eql(0)
     end

--- a/spec/unit/models/message_encoders/cipher_spec.rb
+++ b/spec/unit/models/message_encoders/cipher_spec.rb
@@ -85,7 +85,7 @@ describe Ably::Models::MessageEncoders::Cipher do
         let(:decode_method) { subject.decode message, { encrypted: true, cipher_params: cipher_params } }
 
         it 'raise an exception' do
-          expect { decode_method }.to raise_error Ably::Exceptions::CipherError, /Cipher algorithm [\w\d-]+ does not match message cipher algorithm of AES-128-CBC/
+          expect { decode_method }.to raise_error Ably::Exceptions::CipherError, /Cipher algorithm [\w-]+ does not match message cipher algorithm of AES-128-CBC/
         end
       end
 

--- a/spec/unit/models/token_details_spec.rb
+++ b/spec/unit/models/token_details_spec.rb
@@ -23,31 +23,33 @@ describe Ably::Models::TokenDetails do
       end
     end
 
-    { :issued => :issued, :expires => :expires }.each do |method_name, attribute|
+    context do
       let(:time) { Time.now }
-      context "##{method_name} with :#{method_name} option as milliseconds in constructor" do
-        subject { Ably::Models::TokenDetails.new({ attribute.to_sym => time.to_i * 1000 }) }
+      { :issued => :issued, :expires => :expires }.each do |method_name, attribute|
+        context "##{method_name} with :#{method_name} option as milliseconds in constructor" do
+          subject { Ably::Models::TokenDetails.new({ attribute.to_sym => time.to_i * 1000 }) }
 
-        it "retrieves attribute :#{attribute} as Time" do
-          expect(subject.public_send(method_name)).to be_a(Time)
-          expect(subject.public_send(method_name).to_i).to eql(time.to_i)
+          it "retrieves attribute :#{attribute} as Time" do
+            expect(subject.public_send(method_name)).to be_a(Time)
+            expect(subject.public_send(method_name).to_i).to eql(time.to_i)
+          end
         end
-      end
 
-      context "##{method_name} with :#{method_name} option as a Time in constructor" do
-        subject { Ably::Models::TokenDetails.new({ attribute.to_sym => time }) }
+        context "##{method_name} with :#{method_name} option as a Time in constructor" do
+          subject { Ably::Models::TokenDetails.new({ attribute.to_sym => time }) }
 
-        it "retrieves attribute :#{attribute} as Time" do
-          expect(subject.public_send(method_name)).to be_a(Time)
-          expect(subject.public_send(method_name).to_i).to eql(time.to_i)
+          it "retrieves attribute :#{attribute} as Time" do
+            expect(subject.public_send(method_name)).to be_a(Time)
+            expect(subject.public_send(method_name).to_i).to eql(time.to_i)
+          end
         end
-      end
 
-      context "##{method_name} when converted to JSON" do
-        subject { Ably::Models::TokenDetails.new({ attribute.to_sym => time }) }
+        context "##{method_name} when converted to JSON" do
+          subject { Ably::Models::TokenDetails.new({ attribute.to_sym => time }) }
 
-        it 'is in milliseconds' do
-          expect(JSON.parse(JSON.dump(subject))[convert_to_mixed_case(attribute)]).to eql((time.to_f * 1000).round)
+          it 'is in milliseconds' do
+            expect(JSON.parse(JSON.dump(subject))[convert_to_mixed_case(attribute)]).to eql((time.to_f * 1000).round)
+          end
         end
       end
     end

--- a/spec/unit/modules/event_emitter_spec.rb
+++ b/spec/unit/modules/event_emitter_spec.rb
@@ -75,8 +75,8 @@ describe Ably::Modules::EventEmitter do
           2.times do
             subject.on(:message) do |msg|
               obj.received_message msg
-              subject.on(:message) do |msg|
-                obj.received_message_from_new_callbacks msg
+              subject.on(:message) do |message|
+                obj.received_message_from_new_callbacks message
               end
             end
           end

--- a/spec/unit/modules/state_emitter_spec.rb
+++ b/spec/unit/modules/state_emitter_spec.rb
@@ -320,13 +320,13 @@ describe Ably::Modules::StateEmitter do
     end
 
     it 'is not called if the state does not change' do
-      subject.once_state_changed &block
+      subject.once_state_changed(&block)
       subject.change_state initial_state
       expect(block_calls.count).to eql(0)
     end
 
     it 'calls the block for any state change once' do
-      subject.once_state_changed &block
+      subject.once_state_changed(&block)
       3.times do
         subject.change_state :connected
         subject.change_state :connecting
@@ -335,7 +335,7 @@ describe Ably::Modules::StateEmitter do
     end
 
     it 'emits arguments to the block' do
-      subject.once_state_changed &block
+      subject.once_state_changed(&block)
       subject.change_state :connected, 1, 2
       expect(block_calls.count).to eql(1)
       expect(block_calls.first).to contain_exactly(1, 2)

--- a/spec/unit/modules/state_emitter_spec.rb
+++ b/spec/unit/modules/state_emitter_spec.rb
@@ -30,11 +30,11 @@ describe Ably::Modules::StateEmitter do
   end
 
   specify '#state= sets current state' do
-    expect { subject.state = :connecting }.to change { subject.state }.to(:connecting)
+    expect { subject.state = :connecting }.to change { subject.state.to_sym }.to(:connecting)
   end
 
   specify '#change_state sets current state' do
-    expect { subject.change_state :connecting }.to change { subject.state }.to(:connecting)
+    expect { subject.change_state :connecting }.to change { subject.state.to_sym }.to(:connecting)
   end
 
   context '#change_state with arguments' do
@@ -46,7 +46,7 @@ describe Ably::Modules::StateEmitter do
         expect(callback_args).to eql(args)
         callback_status[:called] = true
       end
-      expect { subject.change_state :connecting, *args }.to change { subject.state }.to(:connecting)
+      expect { subject.change_state :connecting, *args }.to change { subject.state.to_sym }.to(:connecting)
       expect(callback_status).to eql(called: true)
     end
   end

--- a/spec/unit/realtime/channel_spec.rb
+++ b/spec/unit/realtime/channel_spec.rb
@@ -212,25 +212,25 @@ describe Ably::Realtime::Channel do
       end
 
       specify 'with no event name specified unsubscribes that block from all events' do
-        subject.unsubscribe &callback
+        subject.unsubscribe(&callback)
         subject.__incoming_msgbus__.publish(:message, click_message)
         expect(message_history[:received]).to eql(0)
       end
 
       specify 'with a single event name argument unsubscribes the provided block with the matching event name' do
-        subject.unsubscribe click_event, &callback
+        subject.unsubscribe(click_event, &callback)
         subject.__incoming_msgbus__.publish(:message, click_message)
         expect(message_history[:received]).to eql(0)
       end
 
       specify 'with multiple event name arguments unsubscribes each of those matching event names with the provided block' do
-        subject.unsubscribe focus_event, click_event, &callback
+        subject.unsubscribe(focus_event, click_event, &callback)
         subject.__incoming_msgbus__.publish(:message, click_message)
         expect(message_history[:received]).to eql(0)
       end
 
       specify 'with a non-matching event name argument has no effect' do
-        subject.unsubscribe 'move', &callback
+        subject.unsubscribe('move', &callback)
         subject.__incoming_msgbus__.publish(:message, click_message)
         expect(message_history[:received]).to eql(1)
       end

--- a/spec/unit/realtime/connection_spec.rb
+++ b/spec/unit/realtime/connection_spec.rb
@@ -54,7 +54,7 @@ describe Ably::Realtime::Connection do
       it 'registers a callback' do
         subject.on_resume { callbacks << true }
         additional_proc = proc { raise 'This should not be called' }
-        subject.off_resume &additional_proc
+        subject.off_resume(&additional_proc)
         subject.resumed
         expect(callbacks.count).to eql(1)
       end

--- a/spec/unit/realtime/presence_spec.rb
+++ b/spec/unit/realtime/presence_spec.rb
@@ -104,31 +104,31 @@ describe Ably::Realtime::Presence do
       end
 
       specify 'with no action specified unsubscribes that block from all events' do
-        subject.unsubscribe &callback
+        subject.unsubscribe(&callback)
         subject.__incoming_msgbus__.publish(:presence, enter_message)
         expect(message_history[:received]).to eql(0)
       end
 
       specify 'with a single action argument unsubscribes the provided block with the matching action' do
-        subject.unsubscribe enter_action, &callback
+        subject.unsubscribe(enter_action, &callback)
         subject.__incoming_msgbus__.publish(:presence, enter_message)
         expect(message_history[:received]).to eql(0)
       end
 
       specify 'with multiple action arguments unsubscribes each of those matching actions with the provided block' do
-        subject.unsubscribe :update, :leave, enter_action, &callback
+        subject.unsubscribe(:update, :leave, enter_action, &callback)
         subject.__incoming_msgbus__.publish(:presence, enter_message)
         expect(message_history[:received]).to eql(0)
       end
 
       specify 'with a non-matching action argument has no effect' do
-        subject.unsubscribe :leave, &callback
+        subject.unsubscribe(:leave, &callback)
         subject.__incoming_msgbus__.publish(:presence, enter_message)
         expect(message_history[:received]).to eql(1)
       end
 
       specify 'with no block argument unsubscribes all blocks for the action argument' do
-        subject.unsubscribe enter_action
+        subject.unsubscribe(enter_action)
         subject.__incoming_msgbus__.publish(:presence, enter_message)
         expect(message_history[:received]).to eql(0)
       end


### PR DESCRIPTION
@lmars going to merge this ASAP unless you have any objections.

This will remove all the warnings from Ruby when in verbose mode