### PR TITLE
Proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,10 +227,10 @@ secret_key = Ably::Util::Crypto.generate_random_key
 channel = client.channels.get('test', cipher: { key: secret_key })
 channel.publish nil, "sensitive data" # data will be encrypted before publish
 messages_page = channel.history
-messages_page.first.data #=> "sensitive data"
+messages_page.items.first.data #=> "sensitive data"
 ```
 
-### Generate Token
+### Generate a Token
 
 Tokens are issued by Ably and are readily usable by any client to connect to Ably:
 

--- a/ably.gemspec
+++ b/ably.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'statesman', '~> 1.0.0'
   spec.add_runtime_dependency 'faraday', '~> 0.9'
   spec.add_runtime_dependency 'json'
-  spec.add_runtime_dependency 'websocket-driver', '~> 0.6'
+  spec.add_runtime_dependency 'faye-websocket', '~> 0.10.3'
   spec.add_runtime_dependency 'msgpack', '>= 0.6.2'
   spec.add_runtime_dependency 'addressable', '>= 2.0.0'
 

--- a/lib/ably/realtime.rb
+++ b/lib/ably/realtime.rb
@@ -1,5 +1,5 @@
 require 'eventmachine'
-require 'websocket/driver'
+require 'faye/websocket'
 require 'em-http-request'
 
 require 'ably/modules/event_emitter'

--- a/lib/ably/realtime/client.rb
+++ b/lib/ably/realtime/client.rb
@@ -62,6 +62,7 @@ module Ably
       def_delegators :@rest_client, :encoders
       def_delegators :@rest_client, :use_tls?, :protocol, :protocol_binary?
       def_delegators :@rest_client, :environment, :custom_host, :custom_port, :custom_tls_port
+      def_delegators :@rest_client, :proxy, :proxy_url
       def_delegators :@rest_client, :log_level
 
       # Creates a {Ably::Realtime::Client Realtime Client} and configures the {Ably::Auth} object for the connection.
@@ -180,7 +181,7 @@ module Ably
         @fallback_endpoints[fallback_endpoint_index % @fallback_endpoints.count]
       end
 
-      private
+      # @api private
       def endpoint_for_host(host)
         port = if use_tls?
           custom_tls_port

--- a/lib/ably/realtime/connection/websocket_transport.rb
+++ b/lib/ably/realtime/connection/websocket_transport.rb
@@ -2,7 +2,7 @@ module Ably::Realtime
   class Connection
     # EventMachine WebSocket transport
     # @api private
-    class WebsocketTransport < EventMachine::Connection
+    class WebsocketTransport
       include Ably::Modules::EventEmitter
       extend Ably::Modules::Enum
 
@@ -16,114 +16,72 @@ module Ably::Realtime
       )
       include Ably::Modules::StateEmitter
 
+      # URL endpoint including initialization configuration
+      # @return [String]
+      attr_reader :url
+
       def initialize(connection, url)
         @connection = connection
         @state      = STATE.Initialized
         @url        = url
 
-        setup_event_handlers
+        change_state STATE.Connecting
+        setup_driver
       end
 
       # Disconnect the socket transport connection and write all pending text.
       # If Disconnected state is not automatically emitted, it will be emitted automatically
       # @return [void]
-      # @api public
-      def disconnect
-        close_connection_after_writing
-        change_state STATE.Disconnecting
+      def close
+        client.logger.debug "WebsocketTransport closed due to an explicit request"
+        change_state STATE.Disconnecting unless disconnected?
+        driver.close 3099, "WebsocketTransport closed due to an explicit request"
         create_timer(2) do
           # if connection is not disconnected within 2s, set state as disconnected
           change_state STATE.Disconnected unless disconnected?
         end
       end
 
-      # Network connection has been established
-      # Required {http://www.rubydoc.info/github/eventmachine/eventmachine/EventMachine/Connection EventMachine::Connection} interface
-      def post_init
-        clear_timer
-        change_state STATE.Connecting
-        setup_driver
-      end
 
-      # Remote TCP connection attempt completes successfully
-      # Required {http://www.rubydoc.info/github/eventmachine/eventmachine/EventMachine/Connection EventMachine::Connection} interface
-      def connection_completed
-        change_state STATE.Connected
-        start_tls if client.use_tls?
-        driver.start
-      end
-
-      # Called by the event loop whenever data has been received by the network connection.
-      # Simply pass onto the WebSocket driver to process and determine content boundaries.
-      # Required {http://www.rubydoc.info/github/eventmachine/eventmachine/EventMachine/Connection EventMachine::Connection} interface
-      def receive_data(data)
-        driver.parse(data)
-      end
-
-      # Called whenever a connection (either a server or client connection) is closed
-      # Required {http://www.rubydoc.info/github/eventmachine/eventmachine/EventMachine/Connection EventMachine::Connection} interface
-      def unbind
-        change_state STATE.Disconnected, reason_closed || 'Websocket connection closed unexpectedly'
-      end
-
-      # URL end point including initialization configuration
-      # {http://www.rubydoc.info/gems/websocket-driver/0.3.5/WebSocket/Driver WebSocket::Driver} interface
-      def url
-        @url
-      end
-
-      # {http://www.rubydoc.info/gems/websocket-driver/0.3.5/WebSocket/Driver WebSocket::Driver} interface
-      def write(data)
-        send_data(data)
-      end
-
-      # True if socket connection is ready to be released
+      # True when socket connection is ready to be released
       # i.e. it is not currently connecting or connected
+      # @return [Boolean]
       def ready_for_release?
         !connecting? && !connected?
       end
 
-      # @!attribute [r] __incoming_protocol_msgbus__
-      # @return [Ably::Util::PubSub] Websocket Transport internal incoming protocol message bus
+      # Websocket Transport internal incoming protocol message bus
+      # @return [Ably::Util::PubSub]
       # @api private
       def __incoming_protocol_msgbus__
         @__incoming_protocol_msgbus__ ||= create_pub_sub_message_bus
       end
 
-      # @!attribute [r] __outgoing_protocol_msgbus__
-      # @return [Ably::Util::PubSub] Websocket Transport internal outgoing protocol message bus
+      # Websocket Transport internal outgoing protocol message bus
+      # @return [Ably::Util::PubSub]
       # @api private
       def __outgoing_protocol_msgbus__
         @__outgoing_protocol_msgbus__ ||= create_pub_sub_message_bus
       end
 
       private
-      def driver
-        @driver
-      end
 
-      def connection
-        @connection
-      end
-
-      def reason_closed
-        @reason_closed
-      end
+      attr_reader :driver, :connection
 
       # Send object down the WebSocket driver connection as a serialized string/byte array based on protocol
       # @param [Object] object to serialize and send to the WebSocket driver
       def send_object(object)
         case client.protocol
         when :json
-          driver.text(object.to_json)
+          driver.send(object.to_json)
         when :msgpack
-          driver.binary(object.to_msgpack.unpack('C*'))
+          driver.send(object.to_msgpack.unpack('C*'))
         else
           client.logger.fatal "WebsocketTransport: Unsupported protocol '#{client.protocol}' for serialization, object cannot be serialized and sent to Ably over this WebSocket"
         end
       end
 
-      def setup_event_handlers
+      def setup_incoming_message_event_handlers
         __outgoing_protocol_msgbus__.subscribe(:protocol_message) do |protocol_message|
           send_object protocol_message
           client.logger.debug "WebsocketTransport: Prot msg sent =>: #{protocol_message.action} #{protocol_message}"
@@ -143,14 +101,24 @@ module Ably::Realtime
         end
       end
 
-      def setup_driver
-        @driver = WebSocket::Driver.client(self)
+      def options
+        if client.proxy_url
+          { proxy: { origin: client.proxy_url } }
+        else
+          {}
+        end
+      end
 
-        driver.on("open") do
-          logger.debug "WebsocketTransport: socket opened to #{url}, waiting for Connected protocol message"
+      def setup_driver
+        @driver = Faye::WebSocket::Client.new(url, nil, options)
+
+        driver.on(:open) do
+          logger.debug "WebsocketTransport: Websocket opened to #{url}, waiting for Connected protocol message"
+          change_state STATE.Connected
+          setup_incoming_message_event_handlers
         end
 
-        driver.on("message") do |event|
+        driver.on(:message) do |event|
           event_data = parse_event_data(event.data).freeze
           protocol_message = Ably::Models::ProtocolMessage.new(event_data, logger: logger)
           action_name = Ably::Models::ProtocolMessage::ACTION[event_data['action']] rescue event_data['action']
@@ -165,14 +133,16 @@ module Ably::Realtime
           end
         end
 
-        driver.on("error") do |error|
-          logger.error "WebsocketTransport: Protocol Error on transports - #{error.message}"
+        driver.on(:error) do |error|
+          logger.error "WebsocketTransport: Transport protocol error - #{error.message}"
         end
 
-        @reason_closed = nil
-        driver.on("closed") do |event|
-          @reason_closed = "#{event.code}: #{event.reason}"
-          logger.warn "WebsocketTransport: Driver reported transport as closed - #{reason_closed}"
+        driver.on(:close) do |event|
+          unless disconnecting? || connection.closing? || event.code == 3099 # explicit request to close
+            reason_closed = "#{event.code}: #{event.reason}"
+            logger.warn "WebsocketTransport: Driver reported transport as closed - #{reason_closed}"
+          end
+          change_state STATE.Disconnected, event
         end
       end
 

--- a/spec/acceptance/realtime/connection_failures_spec.rb
+++ b/spec/acceptance/realtime/connection_failures_spec.rb
@@ -110,7 +110,7 @@ describe Ably::Realtime::Connection, 'failures', :event_machine do
 
           context 'for the first time' do
             let(:client_options) do
-              default_options.merge(realtime_host: 'non.existent.host', disconnected_retry_timeout: 2, log_level: :error)
+              default_options.merge(realtime_host: 'non.existent.host', disconnected_retry_timeout: 2, log_level: :fatal)
             end
 
             it 'reattempts connection immediately and then waits disconnected_retry_timeout for a subsequent attempt' do
@@ -303,7 +303,7 @@ describe Ably::Realtime::Connection, 'failures', :event_machine do
           context 'when retry intervals are stubbed to attempt reconnection quickly' do
             let(:client_options) do
               default_options.merge(
-                log_level: :error,
+                log_level: :fatal,
                 disconnected_retry_timeout: 0.1,
                 suspended_retry_timeout:    0.1,
                 connection_state_ttl:       0.2,

--- a/spec/acceptance/realtime/connection_failures_spec.rb
+++ b/spec/acceptance/realtime/connection_failures_spec.rb
@@ -399,14 +399,13 @@ describe Ably::Realtime::Connection, 'failures', :event_machine do
                   expect(connection.manager).to receive(:reconnect_transport) do
                     next if stubbed_first_attempt
 
-                    EventMachine.next_tick do
-                      connection.manager.destroy_transport
-                    end
+                    # Open new transport
+                    connection.manager.setup_transport
 
-                    connection.manager.setup_transport do
-                      EventMachine.next_tick do
-                        stubbed_first_attempt = true
-                      end
+                    # But immediately kill it once available
+                    wait_until Proc.new { connection.transport } do
+                      connection.transport.close
+                      stubbed_first_attempt = true
                     end
                   end
                 end

--- a/spec/acceptance/realtime/connection_failures_spec.rb
+++ b/spec/acceptance/realtime/connection_failures_spec.rb
@@ -381,6 +381,10 @@ describe Ably::Realtime::Connection, 'failures', :event_machine do
 
             connection.once(:connected) do
               connection.once(:disconnected) do
+                # Prevent the connection from ever reaching CONNECTED state by
+                # stopping the incoming ProtocolMessage
+                connection.__incoming_protocol_msgbus__.unsubscribe
+
                 connection.once(:connecting) do
                   connection.once(:disconnected) do
                     disconnected_at = Time.now.to_f

--- a/spec/acceptance/realtime/connection_spec.rb
+++ b/spec/acceptance/realtime/connection_spec.rb
@@ -448,7 +448,7 @@ describe Ably::Realtime::Connection, :event_machine do
           close_if_transport_available = proc do
             EventMachine.add_timer(0.001) do
               if connection.transport
-                connection.transport.close_connection_after_writing
+                connection.transport.close
               else
                 close_if_transport_available.call
               end
@@ -1201,7 +1201,7 @@ describe Ably::Realtime::Connection, :event_machine do
               end
             end
 
-            connection.transport.close_connection_after_writing
+            connection.transport.close
           end
         end
       end
@@ -1228,7 +1228,7 @@ describe Ably::Realtime::Connection, :event_machine do
                 if connection.transport.nil?
                   close_connection_proc.call
                 else
-                  connection.transport.close_connection_after_writing
+                  connection.transport.close
                 end
               end
             end
@@ -1327,7 +1327,7 @@ describe Ably::Realtime::Connection, :event_machine do
                 expect(connection_state_change.retry_in).to eql(0)
                 stop_reactor
               end
-              EventMachine.add_timer(0.005) { connection.transport.unbind }
+              EventMachine.add_timer(0.1) { connection.transport.close }
             end
           end
 
@@ -1337,7 +1337,7 @@ describe Ably::Realtime::Connection, :event_machine do
                 expect(connection_state_change.retry_in).to eql(0)
                 stop_reactor
               end
-              connection.transport.unbind
+              connection.transport.close
             end
           end
 
@@ -1348,9 +1348,9 @@ describe Ably::Realtime::Connection, :event_machine do
                   expect(connection_state_change.retry_in).to be > 0
                   stop_reactor
                 end
-                EventMachine.add_timer(0.005) { connection.transport.unbind }
+                EventMachine.add_timer(0.1) { connection.transport.close }
               end
-              connection.transport.unbind
+              connection.transport.close
             end
           end
         end

--- a/spec/acceptance/realtime/connection_spec.rb
+++ b/spec/acceptance/realtime/connection_spec.rb
@@ -1327,7 +1327,9 @@ describe Ably::Realtime::Connection, :event_machine do
                 expect(connection_state_change.retry_in).to eql(0)
                 stop_reactor
               end
-              EventMachine.add_timer(0.1) { connection.transport.close }
+              wait_until Proc.new { connection.transport } do
+                connection.transport.close
+              end
             end
           end
 
@@ -1348,7 +1350,9 @@ describe Ably::Realtime::Connection, :event_machine do
                   expect(connection_state_change.retry_in).to be > 0
                   stop_reactor
                 end
-                EventMachine.add_timer(0.1) { connection.transport.close }
+                wait_until Proc.new { connection.transport } do
+                  connection.transport.close
+                end
               end
               connection.transport.close
             end

--- a/spec/acceptance/realtime/message_spec.rb
+++ b/spec/acceptance/realtime/message_spec.rb
@@ -628,7 +628,7 @@ describe 'Ably::Realtime::Channel Message', :event_machine do
           connection.transport.__outgoing_protocol_msgbus__.subscribe(:protocol_message) do |protocol_message|
             if protocol_message.messages.find { |message| message.name == event_name }
               EventMachine.add_timer(0.001) do
-                connection.transport.unbind # trigger failure
+                connection.transport.close # trigger failure
                 expect(message_state).to be_empty
                 connection.once :connected, &on_reconnected
               end
@@ -661,7 +661,7 @@ describe 'Ably::Realtime::Channel Message', :event_machine do
             connection.transport.__outgoing_protocol_msgbus__.subscribe(:protocol_message) do |protocol_message|
               if protocol_message.messages.find { |message| message.name == event_name }
                 EventMachine.add_timer(0.0001) do
-                  connection.transport.unbind # trigger failure
+                  connection.transport.close # trigger failure
                   connection.configure_new '0123456789abcdef', 'wVIsgTHAB1UvXh7z-1991d8586', -1 # force the resume connection key to be invalid
                 end
               end

--- a/spec/acceptance/realtime/presence_spec.rb
+++ b/spec/acceptance/realtime/presence_spec.rb
@@ -28,7 +28,7 @@ describe Ably::Realtime::Presence, :event_machine do
     def force_connection_failure(client)
       # Prevent any further SYNC messages coming in on this connection
       client.connection.transport.send(:driver).remove_all_listeners('message')
-      client.connection.transport.unbind
+      client.connection.transport.close
     end
 
     shared_examples_for 'a public presence method' do |method_name, expected_state, args, options = {}|

--- a/spec/acceptance/realtime/proxy_spec.rb
+++ b/spec/acceptance/realtime/proxy_spec.rb
@@ -1,0 +1,79 @@
+# encoding: utf-8
+require 'spec_helper'
+require 'ostruct'
+
+describe 'Ably::Realtime::Connection through a Proxy', :event_machine do
+  let(:connection) { client.connection }
+  let(:channel)    { client.channels.get(random_str) }
+  let(:client)     { auto_close Ably::Realtime::Client.new(client_options) }
+  let(:token)      { Ably::Rest::Client.new(key: api_key, environment: environment, protocol: protocol).auth.request_token }
+  let(:default_options) do
+    { token: token, environment: environment, protocol: protocol, disconnected_retry_timeout: 2 }
+  end
+
+  vary_by_protocol do
+    context 'using TLS' do
+      context 'without authentication' do
+        let(:no_auth_proxy_options) do
+          default_options.merge(proxy: { host: 'sandbox-proxy.ably.io', port: 6128 })
+        end
+
+        let(:client_options) { no_auth_proxy_options }
+
+        it 'connects and publishes a message' do
+          connection.on(:connected) do
+            channel.publish('event') do
+              stop_reactor
+            end
+          end
+        end
+      end
+
+      context 'without authentication against an invalid proxy host' do
+        let(:no_auth_proxy_options) do
+          default_options.merge(proxy: { host: 'www.google.com', port: 80 })
+        end
+
+        let(:client_options) { no_auth_proxy_options.merge(log_level: :fatal) }
+
+        it 'fails to connect' do
+          connection.on(:disconnected) do
+            expect(connection.error_reason).to be_a(Ably::Exceptions::ConnectionError)
+            stop_reactor
+          end
+        end
+      end
+
+      context 'with basic authentication' do
+        let(:no_auth_proxy_options) do
+          default_options.merge(proxy: { host: 'sandbox-proxy.ably.io', port: 6129, username: 'ably', password: 'password' })
+        end
+
+        let(:client_options) { no_auth_proxy_options }
+
+        it 'connects and publishes a message' do
+          connection.on(:connected) do
+            channel.publish('event') do
+              stop_reactor
+            end
+          end
+        end
+      end
+
+      context 'with invalid authentication details' do
+        let(:no_auth_proxy_options) do
+          default_options.merge(proxy: { host: 'sandbox-proxy.ably.io', port: 6129, username: 'invalid', password: 'invalid' })
+        end
+
+        let(:client_options) { no_auth_proxy_options.merge(log_level: :fatal) }
+
+        it 'fails to connect' do
+          connection.on(:disconnected) do
+            expect(connection.error_reason).to be_a(Ably::Exceptions::ConnectionError)
+            stop_reactor
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/rest/proxy_spec.rb
+++ b/spec/acceptance/rest/proxy_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+
+describe 'Ably::Rest through a Proxy' do
+  vary_by_protocol do
+    let(:token) { Ably::Rest::Client.new(key: api_key, environment: environment, protocol: protocol).auth.request_token }
+    let(:client) { Ably::Rest::Client.new(client_options) }
+
+    [true, false].each do |tls_enabled|
+      let(:default_options) do
+        { token: token, environment: environment, protocol: protocol, tls: tls_enabled }
+      end
+
+      context "with TLS #{tls_enabled ? 'enabled' : 'disabled'}" do
+        context 'without authentication' do
+          let(:client_options) do
+            default_options.merge(proxy: { host: 'sandbox-proxy.ably.io', port: 6128 })
+          end
+
+          it 'should return the service time as a Time object' do
+            expect(client.time).to be_within(2).of(Time.now)
+          end
+        end
+
+        context 'with authentication' do
+          let(:client_options) do
+            default_options.merge(proxy: { host: 'sandbox-proxy.ably.io', port: 6129, username: 'ably', password: 'password' })
+          end
+
+          it 'should return the service time as a Time object' do
+            expect(client.time).to be_within(2).of(Time.now)
+          end
+
+          context 'and invalid credentials' do
+            let(:client_options) do
+              default_options.merge(proxy: { host: 'sandbox-proxy.ably.io', port: 6129, username: 'wrong', password: 'wrong' })
+            end
+
+            it 'should raise an exception' do
+              expect { client.time }.to raise_error(Ably::Exceptions::InvalidResponseBody)
+            end
+          end
+        end
+
+        context 'with invalid proxy details' do
+          let(:client_options) do
+            default_options.merge(proxy: { host: 'www.google.com', port: 80 })
+          end
+
+          it 'should raise an exception' do
+            expect { client.time }.to raise_error(Ably::Exceptions::InvalidResponseBody)
+          end
+        end
+      end
+    end
+
+    context 'with basic auth' do
+      let(:default_options) do
+        { key: api_key, environment: environment, protocol: protocol, tls: tls_enabled }
+      end
+      let(:client_options) do
+        default_options.merge(proxy: { host: 'sandbox-proxy.ably.io', port: 6128 })
+      end
+
+      context 'with TLS disabled' do
+        let(:tls_enabled) { false }
+
+        before do
+          allow(client.auth).to receive(:ensure_api_key_sent_over_secure_connection)
+        end
+
+        it 'should reject a basic auth request' do
+          expect { client.stats }.to raise_error(Ably::Exceptions::UnauthorizedRequest)
+        end
+      end
+
+      context 'with TLS enabled' do
+        let(:tls_enabled) { true }
+
+        it 'should accept a basic auth request' do
+          client.stats
+        end
+      end
+    end
+  end
+end

--- a/spec/shared/client_initializer_behaviour.rb
+++ b/spec/shared/client_initializer_behaviour.rb
@@ -21,6 +21,11 @@ shared_examples 'a client initializer' do
     subject.kind_of?(Ably::Rest::Client)
   end
 
+  before do
+    # Prevent unit test ever using a real socket transport to connect
+    allow_any_instance_of(Ably::Realtime::Connection::WebsocketTransport).to receive(:new).and_return(double('Websocket').as_null_object)
+  end
+
   context 'with invalid arguments' do
     context 'empty hash' do
       let(:client_options) { Hash.new }
@@ -102,10 +107,6 @@ shared_examples 'a client initializer' do
     end
 
     context 'with a string key instead of options hash' do
-      before do
-        allow_any_instance_of(subject.class).to receive(:auto_connect).and_return(false)
-      end
-
       let(:client_options) { 'app.key:secret' }
 
       it 'sets the key' do
@@ -126,10 +127,6 @@ shared_examples 'a client initializer' do
     end
 
     context 'with a string token key instead of options hash' do
-      before do
-        allow_any_instance_of(subject.class).to receive(:auto_connect).and_return(false)
-      end
-
       let(:client_options) { 'app.kjhkasjhdsakdh127g7g1271' }
 
       it 'sets the token' do
@@ -163,10 +160,6 @@ shared_examples 'a client initializer' do
     end
 
     context 'endpoint' do
-      before do
-        allow_any_instance_of(subject.class).to receive(:auto_connect).and_return(false)
-      end
-
       it 'defaults to production' do
         expect(subject.endpoint.to_s).to eql("#{protocol}s://#{subdomain}.ably.io")
       end
@@ -215,10 +208,6 @@ shared_examples 'a client initializer' do
     end
 
     context 'tls' do
-      before do
-        allow_any_instance_of(subject.class).to receive(:auto_connect).and_return(false)
-      end
-
       context 'set to false' do
         let(:client_options) { default_options.merge(tls: false, auto_connect: false) }
 
@@ -237,10 +226,6 @@ shared_examples 'a client initializer' do
     end
 
     context 'logger' do
-      before do
-        allow_any_instance_of(subject.class).to receive(:auto_connect).and_return(false)
-      end
-
       context 'default' do
         it 'uses Ruby Logger' do
           expect(subject.logger.logger).to be_a(::Logger)
@@ -284,10 +269,6 @@ shared_examples 'a client initializer' do
   end
 
   context 'delegators' do
-    before do
-      allow_any_instance_of(subject.class).to receive(:auto_connect).and_return(false)
-    end
-
     let(:client_options) { 'app.key:secret' }
 
     it 'delegates :client_id to .auth' do

--- a/spec/support/event_machine_helper.rb
+++ b/spec/support/event_machine_helper.rb
@@ -82,7 +82,7 @@ module RSpec
       if condition_block.call
         yield
       else
-        ::EventMachine.add_timer(0.1) do
+        ::EventMachine.add_timer(0.05) do
           wait_until condition_block, &block
         end
       end

--- a/spec/unit/realtime/websocket_transport_spec.rb
+++ b/spec/unit/realtime/websocket_transport_spec.rb
@@ -3,7 +3,8 @@ require 'shared/protocol_msgbus_behaviour'
 
 describe Ably::Realtime::Connection::WebsocketTransport, :api_private do
   let(:client_ignored) { double('Ably::Realtime::Client').as_null_object }
-  let(:connection)     { instance_double('Ably::Realtime::Connection', client: client_ignored, id: nil) }
+  let(:logger)         { double('Logger').as_null_object }
+  let(:connection)     { instance_double('Ably::Realtime::Connection', client: client_ignored, id: nil, logger: logger) }
   let(:url)            { 'http://ably.io/' }
 
   let(:websocket_transport_without_eventmachine) do


### PR DESCRIPTION
@paddybyers see my initial implementation for Proxy support, REST works perfectly.  Unfortunately the [WebSocket](https://www.ably.io/concepts/websockets) library being used does not seem to support proxies correctly, so I've raised an issue at https://github.com/faye/websocket-driver-ruby/issues/40.
