### PR TITLE
Ensure message emitter callbacks are safe (i.e. cannot break the EM)

### DIFF
--- a/lib/ably/modules/message_emitter.rb
+++ b/lib/ably/modules/message_emitter.rb
@@ -4,6 +4,9 @@ module Ably::Modules
   # Message emitter, subscriber and unsubscriber (Pub/Sub) functionality common to Channels and Presence
   # In addition to standard Pub/Sub functionality, it allows subscribers to subscribe to :all.
   module MessageEmitter
+
+    include Ably::Modules::SafeYield
+
     # Subscribe to events on this object
     #
     # @param names [String,Symbol] Optional, the event name(s) to subscribe to. Defaults to `:all` events
@@ -50,8 +53,8 @@ module Ably::Modules
     #
     # @api private
     def emit_message(name, payload)
-      message_emitter_subscriptions[:all].each { |cb| cb.call(payload) }
-      message_emitter_subscriptions[name].each { |cb| cb.call(payload) } if name
+      message_emitter_subscriptions[:all].each { |cb| safe_yield(cb, payload) }
+      message_emitter_subscriptions[name].each { |cb| safe_yield(cb, payload) } if name
     end
 
     private

--- a/spec/acceptance/realtime/presence_spec.rb
+++ b/spec/acceptance/realtime/presence_spec.rb
@@ -1463,6 +1463,25 @@ describe Ably::Realtime::Presence, :event_machine do
           stop_reactor
         end
       end
+
+      context 'with a callback that raises an exception' do
+        let(:exception) { StandardError.new("Intentional error") }
+
+        it 'logs the error and continues' do
+          emitted_exception = false
+          expect(client_one.logger).to receive(:error).with(/#{exception.message}/)
+          presence_client_one.subscribe do |presence_message|
+            emitted_exception = true
+            raise exception
+          end
+          presence_client_one.enter do
+            EventMachine.add_timer(1) do
+              expect(emitted_exception).to eql(true)
+              stop_reactor
+            end
+          end
+        end
+      end
     end
 
     context '#unsubscribe' do


### PR DESCRIPTION
Fixes immediate issue in https://github.com/ably/docs/issues/108