### PR TITLE
Reauthorise

### DIFF
--- a/lib/ably/auth.rb
+++ b/lib/ably/auth.rb
@@ -165,6 +165,12 @@ module Ably
 
       authorise_with_token(request_token(@token_params, auth_options)).tap do |new_token_details|
         logger.debug "Auth: new token following authorisation: #{new_token_details}"
+
+        # If authorise was forced allow a block to be called so that the realtime library
+        # can force upgrade the authorisation
+        if auth_options[:force] && block_given?
+          yield new_token_details
+        end
       end
     end
 

--- a/lib/ably/realtime/auth.rb
+++ b/lib/ably/realtime/auth.rb
@@ -67,7 +67,7 @@ module Ably
       #      token_details #=> Ably::Models::TokenDetails
       #    end
       #
-      def authorise(token_params = {}, auth_options = {}, &success_callback)
+      def authorise(token_params = nil, auth_options = nil, &success_callback)
         async_wrap(success_callback) do
           auth_sync.authorise(token_params, auth_options)
         end.tap do |deferrable|
@@ -82,8 +82,8 @@ module Ably
       # @option (see Ably::Auth#authorise)
       # @return [Ably::Models::TokenDetails]
       #
-      def authorise_sync(token_params = {}, auth_options = {})
-        auth_sync.authorise(token_params, auth_options)
+      def authorise_sync(token_params = nil, auth_options = nil)
+        auth_sync.authorise(token_params, auth_options, &method(:upgrade_authentication_block).to_proc)
       end
 
       # def_delegator :auth_sync, :request_token, :request_token_sync

--- a/lib/ably/realtime/auth.rb
+++ b/lib/ably/realtime/auth.rb
@@ -69,7 +69,7 @@ module Ably
       #
       def authorise(token_params = nil, auth_options = nil, &success_callback)
         async_wrap(success_callback) do
-          auth_sync.authorise(token_params, auth_options)
+          auth_sync.authorise(token_params, auth_options, &method(:upgrade_authentication_block).to_proc)
         end.tap do |deferrable|
           deferrable.errback do |error|
             client.connection.transition_state_machine :failed, reason: error if error.kind_of?(Ably::Exceptions::IncompatibleClientId)
@@ -195,6 +195,24 @@ module Ably
 
       def client
         @client
+      end
+
+      # If authorise is called with true, this block is executed so that it
+      # can perform the authentication upgrade
+      def upgrade_authentication_block(new_token)
+        # This block is called if the authorisation was forced
+        if client.connection.connected? || client.connection.connecting?
+          logger.debug "Realtime::Auth - authorise called with { force: true } so forcibly disconnecting transport to initiate auth upgrade"
+          block = Proc.new do
+            if client.connection.transport
+              logger.debug "Realtime::Auth - current transport disconnected"
+              client.connection.transport.disconnect
+            else
+              EventMachine.add_timer(0.1, &block)
+            end
+          end
+          block.call
+        end
       end
     end
   end

--- a/lib/ably/realtime/connection/connection_manager.rb
+++ b/lib/ably/realtime/connection/connection_manager.rb
@@ -402,7 +402,7 @@ module Ably::Realtime
           @renewing_token = true
           logger.info "ConnectionManager: Token has expired and is renewable, renewing token now"
 
-          client.auth.authorise({}, force: true).tap do |authorise_deferrable|
+          client.auth.authorise(nil, force: true).tap do |authorise_deferrable|
             authorise_deferrable.callback do |token_details|
               logger.info 'ConnectionManager: Token renewed succesfully following expiration'
 

--- a/lib/ably/rest/client.rb
+++ b/lib/ably/rest/client.rb
@@ -376,7 +376,7 @@ module Ably
         yield
       rescue Ably::Exceptions::TokenExpired => e
         if auth.token_renewable?
-          auth.authorise({}, force: true)
+          auth.authorise(nil, force: true)
           yield
         else
           raise e

--- a/spec/acceptance/realtime/auth_spec.rb
+++ b/spec/acceptance/realtime/auth_spec.rb
@@ -254,6 +254,175 @@ describe Ably::Realtime::Auth, :event_machine do
             end
           end
         end
+
+        context 'with force: true to trigger an authentication upgrade' do
+          let(:rest_client)      { Ably::Rest::Client.new(default_options) }
+          let(:client_publisher) { auto_close Ably::Realtime::Client.new(default_options) }
+          let(:basic_capability) { JSON.dump("foo" => ["subscribe"]) }
+          let(:basic_token_cb)   { Proc.new do
+            rest_client.auth.create_token_request({ capability: basic_capability })
+          end }
+          let(:upgraded_capability) { JSON.dump({ "foo" => ["subscribe", "publish"] }) }
+          let(:upgraded_token_cb)   { Proc.new do
+            rest_client.auth.create_token_request({ capability: upgraded_capability })
+          end }
+          let(:identified_token_cb) { Proc.new do
+            rest_client.auth.create_token_request({ client_id: 'bob' })
+          end }
+
+          let(:client_options) { default_options.merge(auth_callback: basic_token_cb) }
+
+          it 'forces the connection to disconnect and reconnect with a new token when in the CONNECTED state' do
+            client.connection.once(:connected) do
+              existing_token = client.auth.current_token_details
+              client.auth.authorise(nil, force: true)
+              client.connection.once(:disconnected) do
+                client.connection.once(:connected) do
+                  expect(existing_token).to_not eql(client.auth.current_token_details)
+                  stop_reactor
+                end
+              end
+            end
+          end
+
+          it 'forces the connection to disconnect and reconnect with a new token when in the CONNECTING state' do
+            client.connection.once(:connecting) do
+              existing_token = client.auth.current_token_details
+              client.auth.authorise(nil, force: true)
+              client.connection.once(:disconnected) do
+                client.connection.once(:connected) do
+                  expect(existing_token).to_not eql(client.auth.current_token_details)
+                  stop_reactor
+                end
+              end
+            end
+          end
+
+          context 'when client is identified' do
+            let(:client_options) { default_options.merge(auth_callback: basic_token_cb, log_level: :none) }
+
+            let(:basic_token_cb)   { Proc.new do
+              rest_client.auth.create_token_request({ client_id: 'mike', capability: basic_capability })
+            end }
+
+            it 'transisitions the connection state to FAILED if the client_id changes' do
+              client.connection.once(:connected) do
+                client.auth.authorise(nil, auth_callback: identified_token_cb, force: true)
+                client.connection.once(:failed) do
+                  expect(client.connection.error_reason.message).to match(/incompatible.*client ID/)
+                  stop_reactor
+                end
+              end
+            end
+          end
+
+          it 'allows an upgrade of capabilities' do
+            skip "Current error from Realtime: Mismatched auth credentials for existing connection"
+
+            client.connection.once(:connected) do
+            client.auth.authorise(nil, auth_callback: upgraded_token_cb, force: true)
+              client.connection.once(:failed) do
+                expect(client.connection.error_reason.message).to match(/incompatible.*client ID/)
+                stop_reactor
+              end
+            end
+          end
+
+          it 'allows an upgrade from anonymous to identified' do
+            skip "Current error from Realtime: Mismatched clientId for existing connection"
+
+            client.connection.once(:connected) do
+            client.auth.authorise(nil, auth_callback: identified_token_cb, force: true)
+              client.connection.once(:failed) do
+                expect(client.connection.error_reason.message).to match(/incompatible.*client ID/)
+                stop_reactor
+              end
+            end
+          end
+
+          it 'ensures message delivery continuity whilst upgrading' do
+            received_messages = []
+            subscriber_channel = client.channels.get('foo')
+            publisher_channel  = client_publisher.channels.get('foo')
+            subscriber_channel.attach do
+              subscriber_channel.subscribe do |message|
+                received_messages << message
+              end
+              publisher_channel.attach do
+                publisher_channel.publish('foo') do
+                  EventMachine.add_timer(2) do
+                    expect(received_messages.length).to eql(1)
+                    client.auth.authorise(nil, force: true)
+                    client.connection.once(:disconnected) do
+                      publisher_channel.publish('bar') do
+                        expect(received_messages.length).to eql(1)
+                      end
+                    end
+                    client.connection.once(:connected) do
+                      EventMachine.add_timer(2) do
+                        expect(received_messages.length).to eql(2)
+                        stop_reactor
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+
+          it 'does not change the connection state if current connection state is closing' do
+            client.connection.once(:connected) do
+              client.connection.once(:closing) do
+                client.auth.authorise(nil, force: true)
+                client.connection.once(:connected) do
+                  raise "Should not reconnect following auth force: true"
+                end
+                EventMachine.add_timer(4) do
+                  expect(client.connection).to be_closed
+                  stop_reactor
+                end
+              end
+              client.connection.close
+            end
+          end
+
+          it 'does not change the connection state if current connection state is closed' do
+            client.connection.once(:connected) do
+              client.connection.once(:closed) do
+                client.auth.authorise(nil, force: true)
+                client.connection.once(:connected) do
+                  raise "Should not reconnect following auth force: true"
+                end
+                EventMachine.add_timer(4) do
+                  expect(client.connection).to be_closed
+                  stop_reactor
+                end
+              end
+              client.connection.close
+            end
+          end
+
+          context 'when state is failed' do
+            let(:client_options) { default_options.merge(auth_callback: basic_token_cb, log_level: :none) }
+
+            it 'does not change the connection state' do
+              client.connection.once(:connected) do
+                client.connection.once(:failed) do
+                  client.auth.authorise(nil, force: true)
+                  client.connection.once(:connected) do
+                    raise "Should not reconnect following auth force: true"
+                  end
+                  EventMachine.add_timer(4) do
+                    expect(client.connection).to be_failed
+                    stop_reactor
+                  end
+                end
+                protocol_message = Ably::Models::ProtocolMessage.new(action: Ably::Models::ProtocolMessage::ACTION.Error.to_i)
+                client.connection.__incoming_protocol_msgbus__.publish :protocol_message, protocol_message
+              end
+            end
+          end
+        end
       end
 
       context '#authorise_async' do


### PR DESCRIPTION
This mirrors the work at https://github.com/ably/ably-js/pull/261, however it tests a few more edge cases. The tests to upgrade capabilities or client_id are marked as pending (`skip`).

See https://github.com/ably/docs/pull/113 for the related spec

@paddybyers @SimonWoolf @lmars 