### PR TITLE
From encoded

### DIFF
--- a/lib/ably/models/message.rb
+++ b/lib/ably/models/message.rb
@@ -1,3 +1,5 @@
+require 'ably/models/message_encoders/base'
+
 module Ably::Models
   # Convert messsage argument to a {Message} object and associate with a protocol message if provided
   #
@@ -42,6 +44,9 @@ module Ably::Models
     include Ably::Modules::Encodeable
     include Ably::Modules::ModelCommon
     include Ably::Modules::SafeDeferrable if defined?(Ably::Realtime)
+
+    # Statically register a default set of encoders for this class
+    Ably::Models::MessageEncoders.register_default_encoders self
 
     # {Message} initializer
     #

--- a/lib/ably/models/message_encoders/base64.rb
+++ b/lib/ably/models/message_encoders/base64.rb
@@ -34,7 +34,7 @@ module Ably::Models::MessageEncoders
     end
 
     def transport_protocol_text?
-      !client.protocol_binary?
+      !options[:binary_protocol]
     end
   end
 end

--- a/lib/ably/models/presence_message.rb
+++ b/lib/ably/models/presence_message.rb
@@ -52,6 +52,9 @@ module Ably::Models
       :update
     )
 
+    # Statically register a default set of encoders for this class
+    Ably::Models::MessageEncoders.register_default_encoders self
+
     # {PresenceMessage} initializer
     #
     # @param  attributes  [Hash]            object with the underlying presence message key value attributes

--- a/lib/ably/modules/encodeable.rb
+++ b/lib/ably/modules/encodeable.rb
@@ -26,6 +26,16 @@ module Ably::Modules
         end
       end
 
+      # Return an Array of Message or Presence objects from the encoded Array of JSON-like objects, using the optional channel options
+      # @param message_objects [Array<Hash>] Array of JSON-like objects with encoded messages
+      # @param channel_options [Hash] Channel options, currently reserved for Encryption options
+      # @return [Array<Message,Presence>]
+      def from_encoded_array(message_object_array, channel_options = {})
+        Array(message_object_array).map do |message_object|
+          from_encoded(message_object, channel_options)
+        end
+      end
+
       # Register an encoder for this object
       # @api private
       def register_encoder(encoder, options = {})

--- a/lib/ably/realtime/channel.rb
+++ b/lib/ably/realtime/channel.rb
@@ -299,7 +299,10 @@ module Ably
 
       def setup_event_handlers
         __incoming_msgbus__.subscribe(:message) do |message|
-          message.decode self
+          message.decode(client.encoders, options) do |encode_error, error_message|
+            client.logger.error error_message
+            emit :error, encode_error
+          end
           emit_message message.name, message
         end
 
@@ -387,7 +390,10 @@ module Ably
 
       def create_message(message)
         Ably::Models::Message(message.dup).tap do |msg|
-          msg.encode self
+          msg.encode(client.encoders, options) do |encode_error, error_message|
+            client.logger.error error_message
+            emit :error, encode_error
+          end
         end
       end
 

--- a/lib/ably/realtime/presence.rb
+++ b/lib/ably/realtime/presence.rb
@@ -346,7 +346,10 @@ module Ably::Realtime
       }
 
       Ably::Models::PresenceMessage.new(model, logger: logger).tap do |presence_message|
-        presence_message.encode self.channel
+        presence_message.encode(client.encoders, channel.options) do |encode_error, error_message|
+          client.logger.error error_message
+          emit :error, encode_error
+        end
       end
     end
 

--- a/lib/ably/realtime/presence/members_map.rb
+++ b/lib/ably/realtime/presence/members_map.rb
@@ -165,7 +165,10 @@ module Ably::Realtime
 
       def setup_event_handlers
         presence.__incoming_msgbus__.subscribe(:presence, :sync) do |presence_message|
-          presence_message.decode channel
+          presence_message.decode(client.encoders, channel.options) do |encode_error, error_message|
+            client.logger.error error_message
+            emit :error, encode_error
+          end
           update_members_and_emit_events presence_message
         end
 

--- a/lib/ably/rest/channel.rb
+++ b/lib/ably/rest/channel.rb
@@ -65,7 +65,7 @@ module Ably
 
         payload = messages.map do |message|
           Ably::Models::Message(message.dup).tap do |msg|
-            msg.encode self
+            msg.encode client.encoders, options
 
             next if msg.client_id.nil?
             if msg.client_id == '*'
@@ -134,7 +134,7 @@ module Ably
       end
 
       def decode_message(message)
-        message.decode self
+        message.decode client.encoders, options
       rescue Ably::Exceptions::CipherError, Ably::Exceptions::EncoderError => e
         client.logger.error "Decoding Error on channel '#{name}', message event name '#{message.name}'. #{e.class.name}: #{e.message}"
       end

--- a/lib/ably/rest/client.rb
+++ b/lib/ably/rest/client.rb
@@ -346,18 +346,8 @@ module Ably
       # @return [void]
       #
       # @api private
-      def register_encoder(encoder)
-        encoder_klass = if encoder.kind_of?(String)
-          encoder.split('::').inject(Kernel) do |base, klass_name|
-            base.public_send(:const_get, klass_name)
-          end
-        else
-          encoder
-        end
-
-        raise "Encoder must inherit from `Ably::Models::MessageEncoders::Base`" unless encoder_klass.ancestors.include?(Ably::Models::MessageEncoders::Base)
-
-        encoders << encoder_klass.new(self)
+      def register_encoder(encoder, options = {})
+        encoders << Ably::Models::MessageEncoders.encoder_from(encoder, options)
       end
 
       # @!attribute [r] protocol_binary?
@@ -535,7 +525,7 @@ module Ably
       end
 
       def initialize_default_encoders
-        Ably::Models::MessageEncoders.register_default_encoders self
+        Ably::Models::MessageEncoders.register_default_encoders self, binary_protocol: protocol == :msgpack
       end
     end
   end

--- a/lib/ably/rest/presence.rb
+++ b/lib/ably/rest/presence.rb
@@ -88,7 +88,7 @@ module Ably
       end
 
       def decode_message(presence_message)
-        presence_message.decode channel
+        presence_message.decode client.encoders, channel.options
       rescue Ably::Exceptions::CipherError, Ably::Exceptions::EncoderError => e
         client.logger.error "Decoding Error on presence channel '#{channel.name}', presence message client_id '#{presence_message.client_id}'. #{e.class.name}: #{e.message}"
       end

--- a/spec/unit/models/message_spec.rb
+++ b/spec/unit/models/message_spec.rb
@@ -481,4 +481,23 @@ describe Ably::Models::Message do
       end
     end
   end
+
+  context '#from_encoded_array (TM3)' do
+    context 'with no encoding' do
+      let(:message_data) do
+        [{ name: 'name1', data: 'data-string' }, { name: 'name2', data: 'data-string' }]
+      end
+      let(:from_encoded) { subject.from_encoded_array(message_data) }
+
+      it 'returns an Array of message objects' do
+        first = from_encoded.first
+        expect(first).to be_a(Ably::Models::Message)
+        expect(first.name).to eql('name1')
+        expect(first.data).to eql('data-string')
+        expect(first.encoding).to be_nil
+        last = from_encoded.last
+        expect(last.name).to eql('name2')
+      end
+    end
+  end
 end

--- a/spec/unit/models/message_spec.rb
+++ b/spec/unit/models/message_spec.rb
@@ -379,4 +379,106 @@ describe Ably::Models::Message do
       end
     end
   end
+
+  context '#from_encoded (TM3)' do
+    context 'with no encoding' do
+      let(:message_data) do
+        { name: 'name', data: 'data-string' }
+      end
+      let(:from_encoded) { subject.from_encoded(message_data) }
+
+      it 'returns a message object' do
+        expect(from_encoded).to be_a(Ably::Models::Message)
+        expect(from_encoded.name).to eql('name')
+        expect(from_encoded.data).to eql('data-string')
+        expect(from_encoded.encoding).to be_nil
+      end
+
+      context 'with a block' do
+        it 'does not call the block' do
+          block_called = false
+          subject.from_encoded(message_data) do |exception, message|
+            block_called = true
+          end
+          expect(block_called).to be_falsey
+        end
+      end
+    end
+
+    context 'with an encoding' do
+      let(:hash_data)           { { 'key' => 'value', 'key2' => 123 } }
+      let(:message_data) do
+        { name: 'name', data: JSON.dump(hash_data), encoding: 'json' }
+      end
+      let(:from_encoded) { subject.from_encoded(message_data) }
+
+      it 'returns a message object' do
+        expect(from_encoded).to be_a(Ably::Models::Message)
+        expect(from_encoded.name).to eql('name')
+        expect(from_encoded.data).to eql(hash_data)
+        expect(from_encoded.encoding).to be_nil
+      end
+    end
+
+    context 'with a custom encoding' do
+      let(:hash_data)           { { 'key' => 'value', 'key2' => 123 } }
+      let(:message_data) do
+        { name: 'name', data: JSON.dump(hash_data), encoding: 'foo/json' }
+      end
+      let(:from_encoded) { subject.from_encoded(message_data) }
+
+      it 'returns a message object with the residual incompatible transforms left in the encoding property' do
+        expect(from_encoded).to be_a(Ably::Models::Message)
+        expect(from_encoded.name).to eql('name')
+        expect(from_encoded.data).to eql(hash_data)
+        expect(from_encoded.encoding).to eql('foo')
+      end
+    end
+
+    context 'with a Cipher encoding' do
+      let(:hash_data)           { { 'key' => 'value', 'key2' => 123 } }
+      let(:cipher_params)       { { key: Ably::Util::Crypto.generate_random_key(128), algorithm: 'aes', mode: 'cbc', key_length: 128 } }
+      let(:crypto)              { Ably::Util::Crypto.new(cipher_params) }
+      let(:payload)             { random_str }
+      let(:message_data) do
+        { name: 'name', data: crypto.encrypt(payload), encoding: 'utf-8/cipher+aes-128-cbc' }
+      end
+      let(:channel_options)     { { cipher: cipher_params } }
+      let(:from_encoded)        { subject.from_encoded(message_data, channel_options) }
+
+      it 'returns a message object with the residual incompatible transforms left in the encoding property' do
+        expect(from_encoded).to be_a(Ably::Models::Message)
+        expect(from_encoded.name).to eql('name')
+        expect(from_encoded.data).to eql(payload)
+        expect(from_encoded.encoding).to be_nil
+      end
+    end
+
+    context 'with invalid Cipher encoding' do
+      let(:hash_data)           { { 'key' => 'value', 'key2' => 123 } }
+      let(:cipher_params)       { { key: Ably::Util::Crypto.generate_random_key(128), algorithm: 'aes', mode: 'cbc', key_length: 128 } }
+      let(:unencryped_payload)  { random_str }
+      let(:message_data) do
+        { name: 'name', data: unencryped_payload, encoding: 'utf-8/cipher+aes-128-cbc' }
+      end
+      let(:channel_options)     { { cipher: cipher_params } }
+
+      context 'without a block' do
+        it 'raises an exception' do
+          expect { subject.from_encoded(message_data, channel_options) }.to raise_exception(Ably::Exceptions::CipherError)
+        end
+      end
+
+      context 'with a block' do
+        it 'calls the block with the exception' do
+          block_called = false
+          subject.from_encoded(message_data, channel_options) do |exception, message|
+            expect(exception).to be_a(Ably::Exceptions::CipherError)
+            block_called = true
+          end
+          expect(block_called).to be_truthy
+        end
+      end
+    end
+  end
 end

--- a/spec/unit/models/presence_message_spec.rb
+++ b/spec/unit/models/presence_message_spec.rb
@@ -485,4 +485,23 @@ describe Ably::Models::PresenceMessage do
       end
     end
   end
+
+  context '#from_encoded_array (TP4)' do
+    context 'with no encoding' do
+      let(:message_data) do
+        [{ action: 1, data: 'data-string' }, { action: 2, data: 'data-string' }]
+      end
+      let(:from_encoded) { subject.from_encoded_array(message_data) }
+
+      it 'returns an Array of presence message objects' do
+        first = from_encoded.first
+        expect(first).to be_a(Ably::Models::PresenceMessage)
+        expect(first.action).to eq(1)
+        expect(first.data).to eql('data-string')
+        expect(first.encoding).to be_nil
+        last = from_encoded.last
+        expect(last.action).to eq(:enter)
+      end
+    end
+  end
 end


### PR DESCRIPTION
FYI @paddybyers @SimonWoolf 

I have implemented `fromEncoded` and `fromEncodedArray` defined in https://github.com/ably/docs/pull/182/files.

It was a bit harder than JS specifically because the encoders are registered with the client, yet the static Message object is not associated with a client.

Shout if you're happy and I'll merge into 0.9
