### PR TITLE
Token details request from json

### DIFF
--- a/lib/ably/exceptions.rb
+++ b/lib/ably/exceptions.rb
@@ -122,5 +122,8 @@ module Ably
     class ChannelInactive < BaseAblyException; end
 
     class IncompatibleClientId < BaseAblyException; end
+
+    # Token request has missing or invalid attributes
+    class InvalidTokenRequest < BaseAblyException; end
   end
 end

--- a/lib/ably/models/message_encoders/base.rb
+++ b/lib/ably/models/message_encoders/base.rb
@@ -15,7 +15,7 @@ module Ably::Models::MessageEncoders
   class Base
     attr_reader :client, :options
 
-    def initialize(client, options)
+    def initialize(client, options = {})
       @client = client
       @options = options
     end

--- a/lib/ably/models/token_details.rb
+++ b/lib/ably/models/token_details.rb
@@ -73,7 +73,17 @@ module Ably::Models
     # @!attribute [r] capability
     # @return [Hash] Capabilities assigned to this token
     def capability
-      JSON.parse(attributes.fetch(:capability)) if attributes.has_key?(:capability)
+      if attributes.has_key?(:capability)
+        capability_val = attributes.fetch(:capability)
+        case capability_val
+        when Hash
+          capability_val
+        when Ably::Models::IdiomaticRubyWrapper
+          capability_val.as_json
+        else
+          JSON.parse(attributes.fetch(:capability))
+        end
+      end
     end
 
     # @!attribute [r] client_id

--- a/lib/ably/models/token_request.rb
+++ b/lib/ably/models/token_request.rb
@@ -42,7 +42,7 @@ module Ably::Models
     # @!attribute [r] key_name
     # @return [String] API key name of the key against which this request is made.  An API key is made up of an API key name and secret delimited by a +:+
     def key_name
-      attributes.fetch(:key_name)
+      attributes.fetch(:key_name) { raise Ably::Exceptions::InvalidTokenRequest, 'Key name is missing' }
     end
 
     # @!attribute [r] ttl
@@ -59,7 +59,16 @@ module Ably::Models
     #                the capability of the returned token will be the intersection of
     #                this capability with the capability of the issuing key.
     def capability
-      JSON.parse(attributes.fetch(:capability))
+      capability_val = attributes.fetch(:capability) { raise Ably::Exceptions::InvalidTokenRequest, 'Capability is missing' }
+
+      case capability_val
+      when Hash
+        capability_val
+      when Ably::Models::IdiomaticRubyWrapper
+        capability_val.as_json
+      else
+        JSON.parse(attributes.fetch(:capability))
+      end
     end
 
     # @!attribute [r] client_id
@@ -75,7 +84,8 @@ module Ably::Models
     #                token requests from being replayed.
     #                Timestamp when sent to Ably is in milliseconds.
     def timestamp
-      as_time_from_epoch(attributes.fetch(:timestamp), granularity: :ms)
+      timestamp_val = attributes.fetch(:timestamp) { raise Ably::Exceptions::InvalidTokenRequest, 'Timestamp is missing' }
+      as_time_from_epoch(timestamp_val, granularity: :ms)
     end
 
     # @!attribute [r] nonce
@@ -83,21 +93,21 @@ module Ably::Models
     #                   uniqueness of this request. Any subsequent request using the
     #                   same nonce will be rejected.
     def nonce
-      attributes.fetch(:nonce)
+      attributes.fetch(:nonce) { raise Ably::Exceptions::InvalidTokenRequest, 'Nonce is missing' }
     end
 
     # @!attribute [r] mac
     # @return [String]  the Message Authentication Code for this request. See the
     #                   {https://www.ably.io/documentation Ably Authentication documentation} for more details.
     def mac
-      attributes.fetch(:mac)
+      attributes.fetch(:mac) { raise Ably::Exceptions::InvalidTokenRequest, 'MAC is missing' }
     end
 
     # Requests that the token is always persisted
     # @api private
     #
     def persisted
-      attributes.fetch(:persisted)
+      attributes[:persisted]
     end
 
     # @!attribute [r] attributes

--- a/lib/ably/modules/model_common.rb
+++ b/lib/ably/modules/model_common.rb
@@ -8,6 +8,10 @@ module Ably::Modules
     include Conversions
     include MessagePack
 
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
     # Provide a normal Hash accessor to the underlying raw message object
     #
     # @return [Object]
@@ -36,6 +40,19 @@ module Ably::Modules
     # @return [Integer] Compute a hash-code for this hash. Two hashes with the same content will have the same hash code
     def hash
       attributes.hash
+    end
+
+    module ClassMethods
+      # Return a new instance of this object using the provided JSON-like object or JSON string
+      # @param [Hash, String] JSON-like object or JSON string
+      # @return a new instance o this object
+      def from_json(json_like_object)
+        if json_like_object.kind_of?(String)
+          new(JSON.parse(json_like_object))
+        else
+          new(json_like_object)
+        end
+      end
     end
 
     private

--- a/lib/ably/realtime/presence/members_map.rb
+++ b/lib/ably/realtime/presence/members_map.rb
@@ -167,7 +167,7 @@ module Ably::Realtime
         presence.__incoming_msgbus__.subscribe(:presence, :sync) do |presence_message|
           presence_message.decode(client.encoders, channel.options) do |encode_error, error_message|
             client.logger.error error_message
-            emit :error, encode_error
+            channel.emit :error, encode_error
           end
           update_members_and_emit_events presence_message
         end

--- a/spec/acceptance/realtime/channel_spec.rb
+++ b/spec/acceptance/realtime/channel_spec.rb
@@ -367,11 +367,11 @@ describe Ably::Realtime::Channel, :event_machine do
             # All 3 messages should be batched into a single Protocol Message by the client library
             # message.id = "{protocol_message.id}:{protocol_message_index}"
             # Check that all messages share the same protocol_message.id
-            message_id = messages.map { |msg| msg.id.split(':')[0] }
+            message_id = messages.map { |msg| msg.id.split(':')[0...-1].join(':') }
             expect(message_id.uniq.count).to eql(1)
 
             # Check that messages use index 0,1,2 in the ID
-            message_indexes = messages.map { |msg| msg.id.split(':')[1] }
+            message_indexes = messages.map { |msg| msg.id.split(':').last }
             expect(message_indexes).to include("0", "1", "2")
             stop_reactor
           end

--- a/spec/acceptance/realtime/presence_spec.rb
+++ b/spec/acceptance/realtime/presence_spec.rb
@@ -1226,11 +1226,11 @@ describe Ably::Realtime::Presence, :event_machine do
         let(:client_options)      { default_options.merge(log_level: :none) }
 
         def connect_members_deferrables
-          (members_per_page * pages + 1).times.map do |index|
+          (members_per_page * pages + 1).times.map do |mem_index|
             # rate limit to 10 per second
             EventMachine::DefaultDeferrable.new.tap do |deferrable|
-              EventMachine.add_timer(index / 10) do
-                presence_client_one.enter_client("client:#{index}").tap do |enter_deferrable|
+              EventMachine.add_timer(mem_index/10) do
+                presence_client_one.enter_client("client:#{mem_index}").tap do |enter_deferrable|
                   enter_deferrable.callback { |*args| deferrable.succeed *args }
                   enter_deferrable.errback { |*args| deferrable.fail *args }
                 end

--- a/spec/unit/models/message_encoders/base64_spec.rb
+++ b/spec/unit/models/message_encoders/base64_spec.rb
@@ -57,8 +57,9 @@ describe Ably::Models::MessageEncoders::Base64 do
 
   context '#encode' do
     context 'over binary transport' do
+      subject { Ably::Models::MessageEncoders::Base64.new(client, binary_protocol: true) }
+
       before do
-        allow(client).to receive(:protocol_binary?).and_return(true)
         subject.encode message, {}
       end
 

--- a/spec/unit/models/token_details_spec.rb
+++ b/spec/unit/models/token_details_spec.rb
@@ -146,4 +146,79 @@ describe Ably::Models::TokenDetails do
       end
     end
   end
+
+  context 'from_json (TD7)' do
+    let(:issued_time) { Time.now }
+    let(:expires_time) { Time.now + 24*60*60 }
+    let(:capabilities) { { '*' => ['publish'] } }
+
+    context 'with Ruby idiomatic Hash object' do
+      subject { Ably::Models::TokenDetails.from_json(token_details_object) }
+
+      let(:token_details_object) do
+        {
+          token: 'val1',
+          key_name: 'val2',
+          issued: issued_time.to_i * 1000,
+          expires: expires_time.to_i * 1000,
+          capability: capabilities,
+          client_id: 'val3'
+        }
+      end
+
+      it 'returns a valid TokenDetails object' do
+        expect(subject.token).to eql('val1')
+        expect(subject.key_name).to eql('val2')
+        expect(subject.issued.to_f).to be_within(1).of(issued_time.to_f)
+        expect(subject.expires.to_f).to be_within(1).of(expires_time.to_f)
+        expect(subject.capability).to eql(capabilities)
+        expect(subject.client_id).to eql('val3')
+      end
+    end
+
+    context 'with JSON-like object' do
+      subject { Ably::Models::TokenDetails.from_json(token_details_object) }
+
+      let(:token_details_object) do
+        {
+          'keyName' => 'val2',
+          'issued' => issued_time.to_i * 1000,
+          'expires' => expires_time.to_i * 1000,
+          'capability' => JSON.dump(capabilities),
+          'clientId' => 'val3'
+        }
+      end
+
+      it 'returns a valid TokenDetails object' do
+        expect(subject.token).to be_nil
+        expect(subject.key_name).to eql('val2')
+        expect(subject.issued.to_f).to be_within(1).of(issued_time.to_f)
+        expect(subject.expires.to_f).to be_within(1).of(expires_time.to_f)
+        expect(subject.capability).to eql(capabilities)
+        expect(subject.client_id).to eql('val3')
+      end
+    end
+
+    context 'with JSON string' do
+      subject { Ably::Models::TokenDetails.from_json(JSON.dump(token_details_object)) }
+
+      let(:token_details_object) do
+        {
+          'keyName' => 'val2',
+          'issued' => issued_time.to_i * 1000,
+          'expires' => expires_time.to_i * 1000,
+          'clientId' => 'val3'
+        }
+      end
+
+      it 'returns a valid TokenDetails object' do
+        expect(subject.token).to be_nil
+        expect(subject.key_name).to eql('val2')
+        expect(subject.issued.to_f).to be_within(1).of(issued_time.to_f)
+        expect(subject.expires.to_f).to be_within(1).of(expires_time.to_f)
+        expect(subject.capability).to be_nil
+        expect(subject.client_id).to eql('val3')
+      end
+    end
+  end
 end

--- a/spec/unit/models/token_request_spec.rb
+++ b/spec/unit/models/token_request_spec.rb
@@ -107,4 +107,78 @@ describe Ably::Models::TokenRequest do
       end
     end
   end
+
+  context 'from_json (TE6)' do
+    let(:timestamp) { Time.now }
+    let(:capabilities) { { '*' => ['publish'] } }
+    let(:ttl_seconds) { 60 * 1000 }
+
+    context 'with Ruby idiomatic Hash object' do
+      subject { Ably::Models::TokenRequest.from_json(token_request_object) }
+
+      let(:token_request_object) do
+        {
+          nonce: 'val1',
+          key_name: 'val2',
+          ttl: ttl_seconds * 1000,
+          timestamp: timestamp.to_i * 1000,
+          capability: capabilities,
+          client_id: 'val3'
+        }
+      end
+
+      it 'returns a valid TokenRequest object' do
+        expect(subject.nonce).to eql('val1')
+        expect(subject.key_name).to eql('val2')
+        expect(subject.timestamp.to_f).to be_within(1).of(timestamp.to_f)
+        expect(subject.ttl).to eql(ttl_seconds)
+        expect(subject.capability).to eql(capabilities)
+        expect(subject.client_id).to eql('val3')
+      end
+    end
+
+    context 'with JSON-like object' do
+      subject { Ably::Models::TokenRequest.from_json(token_request_object) }
+
+      let(:token_request_object) do
+        {
+          'keyName' => 'val2',
+          'ttl' => ttl_seconds * 1000,
+          'timestamp' => timestamp.to_i * 1000,
+          'clientId' => 'val3'
+        }
+      end
+
+      it 'returns a valid TokenRequest object' do
+        expect { subject.nonce }.to raise_error(Ably::Exceptions::InvalidTokenRequest)
+        expect(subject.key_name).to eql('val2')
+        expect(subject.timestamp.to_f).to be_within(1).of(timestamp.to_f)
+        expect(subject.ttl).to eql(ttl_seconds)
+        expect { subject.capability }.to raise_error(Ably::Exceptions::InvalidTokenRequest)
+        expect(subject.client_id).to eql('val3')
+      end
+    end
+
+    context 'with JSON string' do
+      subject { Ably::Models::TokenRequest.from_json(JSON.dump(token_request_object)) }
+
+      let(:token_request_object) do
+        {
+          'nonce' => 'val1',
+          'ttl' => ttl_seconds * 1000,
+          'capability' => JSON.dump(capabilities),
+          'clientId' => 'val3'
+        }
+      end
+
+      it 'returns a valid TokenRequest object' do
+        expect(subject.nonce).to eql('val1')
+        expect { subject.key_name }.to raise_error(Ably::Exceptions::InvalidTokenRequest)
+        expect { subject.timestamp }.to raise_error(Ably::Exceptions::InvalidTokenRequest)
+        expect(subject.ttl).to eql(ttl_seconds)
+        expect(subject.capability).to eql(capabilities)
+        expect(subject.client_id).to eql('val3')
+      end
+    end
+  end
 end


### PR DESCRIPTION
@SimonWoolf here is the Ruby implementation for https://github.com/ably/docs/pull/193/files

I think you added the from_json method to TokenParams instead of TokenRequest though, so assumed that will be changed along with the new code TE6

cc @paddybyers 