### PR TITLE
0.8: Fix timing issues with ACK/message received

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,52 @@
 # Change Log
 
-## [v0.8.14](https://github.com/ably/ably-ruby/tree/v0.8.14)
+## [v0.8.15](https://github.com/ably/ably-ruby/tree/v0.8.15)
 
+[Full Changelog](https://github.com/ably/ably-ruby/compare/v0.8.14...v0.8.15)
+
+**Implemented enhancements:**
+
+- Fix HttpRequest & HttpRetry timeouts [\#110](https://github.com/ably/ably-ruby/issues/110)
+- Logger should take blocks [\#107](https://github.com/ably/ably-ruby/issues/107)
+- 0.9: Use separate internal/external listeners [\#106](https://github.com/ably/ably-ruby/issues/106)
+- Add reuse library test [\#83](https://github.com/ably/ably-ruby/issues/83)
+- 0.8 final spec check [\#71](https://github.com/ably/ably-ruby/issues/71)
+- Use connection\#id not connection\#key to determine if connection has been resumed [\#62](https://github.com/ably/ably-ruby/issues/62)
+- Channel Presence suspended state [\#41](https://github.com/ably/ably-ruby/issues/41)
+- Attach / detach timeouts + protocol error handling for Channel [\#38](https://github.com/ably/ably-ruby/issues/38)
+- Connection retry and timeout needs to be configurable [\#6](https://github.com/ably/ably-ruby/issues/6)
+
+**Fixed bugs:**
+
+- Subscribing to all connection state changes doesn't work [\#103](https://github.com/ably/ably-ruby/issues/103)
+- Ensure DETACHED or DISCONNECTED with error is non-fatal [\#93](https://github.com/ably/ably-ruby/issues/93)
+- Incorrect assumption for channel errors [\#91](https://github.com/ably/ably-ruby/issues/91)
+- authCallback assumes a blocking callback, even in EM [\#89](https://github.com/ably/ably-ruby/issues/89)
+- Token Reauth error codes [\#86](https://github.com/ably/ably-ruby/issues/86)
+- Do not persist authorise attributes force & timestamp [\#72](https://github.com/ably/ably-ruby/issues/72)
+- 0.8 final spec check [\#71](https://github.com/ably/ably-ruby/issues/71)
+- Receiving CONNECTED when already connected [\#69](https://github.com/ably/ably-ruby/issues/69)
+- Connection\#connect callback may not be called as expected [\#68](https://github.com/ably/ably-ruby/issues/68)
+- nodename nor servname provided [\#65](https://github.com/ably/ably-ruby/issues/65)
+- Channel Presence suspended state [\#41](https://github.com/ably/ably-ruby/issues/41)
+- Intermittent test fixes [\#33](https://github.com/ably/ably-ruby/issues/33)
+
+**Closed issues:**
+
+- Remove deprecated ProtocolMessage\#connectionKey [\#108](https://github.com/ably/ably-ruby/issues/108)
+- 0.9 Extras field [\#105](https://github.com/ably/ably-ruby/issues/105)
+- 0.9 UPDATE spec [\#104](https://github.com/ably/ably-ruby/issues/104)
+- Token issue bug [\#75](https://github.com/ably/ably-ruby/issues/75)
+- Ensure client\_id provided is string or cast to string in Auth request\_token [\#74](https://github.com/ably/ably-ruby/issues/74)
+- Standardise timeouts [\#64](https://github.com/ably/ably-ruby/issues/64)
+- Ensure RSpec retry compatibility is used [\#54](https://github.com/ably/ably-ruby/issues/54)
+- Spec validation [\#43](https://github.com/ably/ably-ruby/issues/43)
+
+**Merged pull requests:**
+
+- From encoded [\#101](https://github.com/ably/ably-ruby/pull/101) ([mattheworiordan](https://github.com/mattheworiordan))
+
+## [v0.8.14](https://github.com/ably/ably-ruby/tree/v0.8.14) (2016-09-30)
 [Full Changelog](https://github.com/ably/ably-ruby/compare/v0.8.13...v0.8.14)
 
 **Fixed bugs:**
@@ -17,7 +62,6 @@
 - Fallback host improvements [\#97](https://github.com/ably/ably-ruby/pull/97) ([mattheworiordan](https://github.com/mattheworiordan))
 
 ## [v0.8.13](https://github.com/ably/ably-ruby/tree/v0.8.13) (2016-09-29)
-
 [Full Changelog](https://github.com/ably/ably-ruby/compare/v0.8.12...v0.8.13)
 
 **Merged pull requests:**
@@ -25,7 +69,6 @@
 - Ensure interoperability with other libraries with JSON protocol [\#94](https://github.com/ably/ably-ruby/pull/94) ([mattheworiordan](https://github.com/mattheworiordan))
 
 ## [v0.8.12](https://github.com/ably/ably-ruby/tree/v0.8.12) (2016-05-23)
-
 [Full Changelog](https://github.com/ably/ably-ruby/compare/v0.8.11...v0.8.12)
 
 **Fixed bugs:**
@@ -37,7 +80,6 @@
 - Reauthorise [\#90](https://github.com/ably/ably-ruby/pull/90) ([mattheworiordan](https://github.com/mattheworiordan))
 
 ## [v0.8.11](https://github.com/ably/ably-ruby/tree/v0.8.11) (2016-04-05)
-
 [Full Changelog](https://github.com/ably/ably-ruby/compare/v0.8.10...v0.8.11)
 
 **Merged pull requests:**
@@ -45,17 +87,14 @@
 - Ensure message emitter callbacks are safe \(i.e. cannot break the EM\) [\#85](https://github.com/ably/ably-ruby/pull/85) ([mattheworiordan](https://github.com/mattheworiordan))
 
 ## [v0.8.10](https://github.com/ably/ably-ruby/tree/v0.8.10) (2016-04-01)
-
 [Full Changelog](https://github.com/ably/ably-ruby/compare/v0.8.9...v0.8.10)
 
 ## [v0.8.9](https://github.com/ably/ably-ruby/tree/v0.8.9) (2016-03-01)
-
 [Full Changelog](https://github.com/ably/ably-ruby/compare/v0.8.8...v0.8.9)
 
 **Fixed bugs:**
 
 - Support enter\(data\) [\#79](https://github.com/ably/ably-ruby/issues/79)
-
 - Update documentation to hide private API methods [\#77](https://github.com/ably/ably-ruby/issues/77)
 
 **Closed issues:**
@@ -65,11 +104,9 @@
 **Merged pull requests:**
 
 - Various fixes for open issues [\#82](https://github.com/ably/ably-ruby/pull/82) ([mattheworiordan](https://github.com/mattheworiordan))
-
 - Encryption spec update [\#81](https://github.com/ably/ably-ruby/pull/81) ([mattheworiordan](https://github.com/mattheworiordan))
 
 ## [v0.8.8](https://github.com/ably/ably-ruby/tree/v0.8.8) (2016-01-26)
-
 [Full Changelog](https://github.com/ably/ably-ruby/compare/v0.8.7...v0.8.8)
 
 **Closed issues:**
@@ -77,23 +114,18 @@
 - Support :key in ClientOptions and deprecate :api\_key [\#73](https://github.com/ably/ably-ruby/issues/73)
 
 ## [v0.8.7](https://github.com/ably/ably-ruby/tree/v0.8.7) (2015-12-31)
-
 [Full Changelog](https://github.com/ably/ably-ruby/compare/v0.8.6...v0.8.7)
 
 ## [v0.8.6](https://github.com/ably/ably-ruby/tree/v0.8.6) (2015-12-02)
-
 [Full Changelog](https://github.com/ably/ably-ruby/compare/v0.8.5...v0.8.6)
 
 **Merged pull requests:**
 
 - Some intermittent test fixes & enable tests that were blocked [\#70](https://github.com/ably/ably-ruby/pull/70) ([mattheworiordan](https://github.com/mattheworiordan))
-
 - Output detailed log for any text failures [\#67](https://github.com/ably/ably-ruby/pull/67) ([mattheworiordan](https://github.com/mattheworiordan))
-
 - 0.8 final spec \(98% compliance\) [\#66](https://github.com/ably/ably-ruby/pull/66) ([mattheworiordan](https://github.com/mattheworiordan))
 
 ## [v0.8.5](https://github.com/ably/ably-ruby/tree/v0.8.5) (2015-10-08)
-
 [Full Changelog](https://github.com/ably/ably-ruby/compare/v0.8.4...v0.8.5)
 
 **Implemented enhancements:**
@@ -103,9 +135,7 @@
 **Fixed bugs:**
 
 - Switch arity of auth methods [\#61](https://github.com/ably/ably-ruby/issues/61)
-
 - Add test: Message published, connection dropped, then restores to point before last message was published [\#56](https://github.com/ably/ably-ruby/issues/56)
-
 - Documentation for constructor is incorrect [\#49](https://github.com/ably/ably-ruby/issues/49)
 
 **Merged pull requests:**
@@ -113,41 +143,30 @@
 - Ensure connections are always closed in tests [\#63](https://github.com/ably/ably-ruby/pull/63) ([mattheworiordan](https://github.com/mattheworiordan))
 
 ## [v0.8.4](https://github.com/ably/ably-ruby/tree/v0.8.4) (2015-09-08)
-
 [Full Changelog](https://github.com/ably/ably-ruby/compare/v0.8.3...v0.8.4)
 
 **Implemented enhancements:**
 
 - Add compatibility support for default Crypto params [\#53](https://github.com/ably/ably-ruby/issues/53)
-
 - EventEmitter on connection [\#52](https://github.com/ably/ably-ruby/issues/52)
-
 - Add test for connectionId attribute for a message sent over REST [\#50](https://github.com/ably/ably-ruby/issues/50)
 
 **Merged pull requests:**
 
 - Spec update to fix a number of issues [\#60](https://github.com/ably/ably-ruby/pull/60) ([mattheworiordan](https://github.com/mattheworiordan))
-
 - Allow clientId to be provided on init if using externally created token [\#58](https://github.com/ably/ably-ruby/pull/58) ([SimonWoolf](https://github.com/SimonWoolf))
 
 ## [v0.8.3](https://github.com/ably/ably-ruby/tree/v0.8.3) (2015-08-19)
-
 [Full Changelog](https://github.com/ably/ably-ruby/compare/v0.8.2...v0.8.3)
 
 **Implemented enhancements:**
 
 - Implement :queue\_messages option [\#36](https://github.com/ably/ably-ruby/issues/36)
-
 - Check that a non 200-299 status code for REST requests uses fallback hosts [\#35](https://github.com/ably/ably-ruby/issues/35)
-
 - Move stats fixtures into ably-common [\#34](https://github.com/ably/ably-ruby/issues/34)
-
 - Add tests for messages with no data or name fields [\#21](https://github.com/ably/ably-ruby/issues/21)
-
 - Namespace MsgPack as MsgPack5 because compliance is not merged in [\#12](https://github.com/ably/ably-ruby/issues/12)
-
 - Add test coverage for receiving messages more than once i.e. historical messages resent somehow on reconnect [\#11](https://github.com/ably/ably-ruby/issues/11)
-
 - Add async methods for Authentication in the realtime library [\#8](https://github.com/ably/ably-ruby/issues/8)
 
 **Fixed bugs:**
@@ -157,37 +176,28 @@
 **Closed issues:**
 
 - Scope default token params in arguments [\#55](https://github.com/ably/ably-ruby/issues/55)
-
 - Channel options can be reset when accessing a channel with \#get [\#46](https://github.com/ably/ably-ruby/issues/46)
 
 **Merged pull requests:**
 
 - Separate token params for auth [\#57](https://github.com/ably/ably-ruby/pull/57) ([mattheworiordan](https://github.com/mattheworiordan))
-
 - Ensure files are required in a consistent order [\#51](https://github.com/ably/ably-ruby/pull/51) ([SimonWoolf](https://github.com/SimonWoolf))
 
 ## [v0.8.2](https://github.com/ably/ably-ruby/tree/v0.8.2) (2015-05-20)
-
 [Full Changelog](https://github.com/ably/ably-ruby/compare/v0.8.1...v0.8.2)
 
 **Implemented enhancements:**
 
 - Ensure Array object can be used in place of Hash for payload [\#44](https://github.com/ably/ably-ruby/issues/44)
-
 - Change connect\_automatically option to auto\_connect for consistency [\#42](https://github.com/ably/ably-ruby/issues/42)
-
 - Rename PaginatedResource to PaginatedResult for consistency [\#40](https://github.com/ably/ably-ruby/issues/40)
-
 - EventEmitter should use `emit` not `trigger` to be consistent with other libs [\#31](https://github.com/ably/ably-ruby/issues/31)
-
 - Add exceptions when data attribute for messages/presence is not String, Binary or JSON data [\#4](https://github.com/ably/ably-ruby/issues/4)
-
 - Auth Callback and Auth URL should support tokens as well as token requests [\#2](https://github.com/ably/ably-ruby/issues/2)
 
 **Closed issues:**
 
 - Realtime Presence\#get does not wait by default [\#47](https://github.com/ably/ably-ruby/issues/47)
-
 - No implicit attach when accessing channel.presence [\#45](https://github.com/ably/ably-ruby/issues/45)
 
 **Merged pull requests:**
@@ -195,11 +205,9 @@
 - Reject invalid payload type [\#48](https://github.com/ably/ably-ruby/pull/48) ([mattheworiordan](https://github.com/mattheworiordan))
 
 ## [v0.8.1](https://github.com/ably/ably-ruby/tree/v0.8.1) (2015-04-23)
-
 [Full Changelog](https://github.com/ably/ably-ruby/compare/v0.8.0...v0.8.1)
 
 ## [v0.8.0](https://github.com/ably/ably-ruby/tree/v0.8.0) (2015-04-23)
-
 [Full Changelog](https://github.com/ably/ably-ruby/compare/v0.7.6...v0.8.0)
 
 **Merged pull requests:**
@@ -207,18 +215,15 @@
 - Token naming refactor [\#29](https://github.com/ably/ably-ruby/pull/29) ([mattheworiordan](https://github.com/mattheworiordan))
 
 ## [v0.7.6](https://github.com/ably/ably-ruby/tree/v0.7.6) (2015-04-17)
-
 [Full Changelog](https://github.com/ably/ably-ruby/compare/v0.7.5...v0.7.6)
 
 **Implemented enhancements:**
 
 - Rename Stat to Stats for consistency [\#32](https://github.com/ably/ably-ruby/issues/32)
-
 - Stats objects [\#24](https://github.com/ably/ably-ruby/issues/24)
-
 - Need a test to handle errors in callbacks [\#13](https://github.com/ably/ably-ruby/issues/13)
-
 - Allow token ID or API key in the client constructor [\#5](https://github.com/ably/ably-ruby/issues/5)
+- Typed stats similar to Java library + zero default for empty stats [\#25](https://github.com/ably/ably-ruby/pull/25) ([mattheworiordan](https://github.com/mattheworiordan))
 
 **Fixed bugs:**
 
@@ -231,19 +236,14 @@
 **Merged pull requests:**
 
 - Test encoded presence fixture data for \#get & \#history [\#28](https://github.com/ably/ably-ruby/pull/28) ([mattheworiordan](https://github.com/mattheworiordan))
-
 - Add coveralls.io coverage reporting [\#27](https://github.com/ably/ably-ruby/pull/27) ([mattheworiordan](https://github.com/mattheworiordan))
-
 - New paginated resource [\#26](https://github.com/ably/ably-ruby/pull/26) ([mattheworiordan](https://github.com/mattheworiordan))
-
-- Typed stats similar to Java library + zero default for empty stats [\#25](https://github.com/ably/ably-ruby/pull/25) ([mattheworiordan](https://github.com/mattheworiordan))
+- History since attach [\#22](https://github.com/ably/ably-ruby/pull/22) ([mattheworiordan](https://github.com/mattheworiordan))
 
 ## [v0.7.5](https://github.com/ably/ably-ruby/tree/v0.7.5) (2015-03-21)
-
 [Full Changelog](https://github.com/ably/ably-ruby/compare/v0.7.4...v0.7.5)
 
 ## [v0.7.4](https://github.com/ably/ably-ruby/tree/v0.7.4) (2015-03-21)
-
 [Full Changelog](https://github.com/ably/ably-ruby/compare/v0.7.2...v0.7.4)
 
 **Merged pull requests:**
@@ -251,7 +251,6 @@
 - Presence Member Map [\#14](https://github.com/ably/ably-ruby/pull/14) ([mattheworiordan](https://github.com/mattheworiordan))
 
 ## [v0.7.2](https://github.com/ably/ably-ruby/tree/v0.7.2) (2015-02-10)
-
 [Full Changelog](https://github.com/ably/ably-ruby/compare/v0.7.1...v0.7.2)
 
 **Implemented enhancements:**
@@ -261,15 +260,12 @@
 **Merged pull requests:**
 
 - Update README to include various missing snippets for core features [\#9](https://github.com/ably/ably-ruby/pull/9) ([kouno](https://github.com/kouno))
-
 - Fix connection retry frequency [\#7](https://github.com/ably/ably-ruby/pull/7) ([kouno](https://github.com/kouno))
 
 ## [v0.7.1](https://github.com/ably/ably-ruby/tree/v0.7.1) (2015-01-18)
-
 [Full Changelog](https://github.com/ably/ably-ruby/compare/v0.7.0...v0.7.1)
 
 ## [v0.7.0](https://github.com/ably/ably-ruby/tree/v0.7.0) (2015-01-12)
-
 [Full Changelog](https://github.com/ably/ably-ruby/compare/v0.6.2...v0.7.0)
 
 **Closed issues:**
@@ -277,39 +273,30 @@
 - JSON encoder should only append utf-8 before a cipher encoder is applied [\#1](https://github.com/ably/ably-ruby/issues/1)
 
 ## [v0.6.2](https://github.com/ably/ably-ruby/tree/v0.6.2) (2014-12-10)
-
 [Full Changelog](https://github.com/ably/ably-ruby/compare/v0.2.0...v0.6.2)
 
 ## [v0.2.0](https://github.com/ably/ably-ruby/tree/v0.2.0) (2014-12-09)
-
 [Full Changelog](https://github.com/ably/ably-ruby/compare/v0.1.6...v0.2.0)
 
 ## [v0.1.6](https://github.com/ably/ably-ruby/tree/v0.1.6) (2014-10-31)
-
 [Full Changelog](https://github.com/ably/ably-ruby/compare/v0.1.5...v0.1.6)
 
 ## [v0.1.5](https://github.com/ably/ably-ruby/tree/v0.1.5) (2014-10-23)
-
 [Full Changelog](https://github.com/ably/ably-ruby/compare/v0.1.4...v0.1.5)
 
 ## [v0.1.4](https://github.com/ably/ably-ruby/tree/v0.1.4) (2014-09-27)
-
 [Full Changelog](https://github.com/ably/ably-ruby/compare/v0.1.3...v0.1.4)
 
 ## [v0.1.3](https://github.com/ably/ably-ruby/tree/v0.1.3) (2014-09-26)
-
 [Full Changelog](https://github.com/ably/ably-ruby/compare/v0.1.2...v0.1.3)
 
 ## [v0.1.2](https://github.com/ably/ably-ruby/tree/v0.1.2) (2014-09-25)
-
 [Full Changelog](https://github.com/ably/ably-ruby/compare/v0.1.1...v0.1.2)
 
 ## [v0.1.1](https://github.com/ably/ably-ruby/tree/v0.1.1) (2014-09-23)
-
 [Full Changelog](https://github.com/ably/ably-ruby/compare/v0.1.0...v0.1.1)
 
 ## [v0.1.0](https://github.com/ably/ably-ruby/tree/v0.1.0) (2014-09-23)
-
 
 
 \* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*

--- a/ably.gemspec
+++ b/ably.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.2.0' # version lock, see config.around(:example, :event_machine) in event_machine_helper.rb
   spec.add_development_dependency 'rspec-retry'
   spec.add_development_dependency 'yard'
-  spec.add_development_dependency 'webmock'
+  spec.add_development_dependency 'webmock', '~> 2.3.0'
 
   spec.add_development_dependency 'coveralls'
 

--- a/lib/ably/modules/model_common.rb
+++ b/lib/ably/modules/model_common.rb
@@ -32,6 +32,14 @@ module Ably::Modules
       as_json.to_json(*args)
     end
 
+    # Like to_json but encodes all binary fields to hex
+    def to_safe_json(*args)
+      as_json.
+        each_with_object({}) do |(key, val), obj|
+          obj[key] = to_safe_jsonable_val(val)
+        end.to_json(*args)
+    end
+
     # @!attribute [r] hash
     # @return [Integer] Compute a hash-code for this hash. Two hashes with the same content will have the same hash code
     def hash
@@ -39,6 +47,23 @@ module Ably::Modules
     end
 
     private
+    def to_safe_jsonable_val(val)
+      case val
+      when Array
+        val.map { |array_val| to_safe_jsonable_val(array_val) }
+      when Hash
+        val.each_with_object({}) { |(key, hash_val), obj| obj[key] = to_safe_jsonable_val(hash_val) }
+      when String
+        if val.encoding == Encoding::ASCII_8BIT
+          val.unpack("H*").first
+        else
+          val
+        end
+      else
+        val
+      end
+    end
+
     def ensure_utf8_string_for(attribute, value)
       if value
         raise ArgumentError, "#{attribute} must be a String" unless value.kind_of?(String)

--- a/lib/ably/realtime/channel/channel_manager.rb
+++ b/lib/ably/realtime/channel/channel_manager.rb
@@ -76,10 +76,10 @@ module Ably::Realtime
 
       def nack_messages(protocol_message, error)
         (protocol_message.messages + protocol_message.presence).each do |message|
-          logger.debug "Calling NACK failure callbacks for #{message.class.name} - #{message.to_json}, protocol message: #{protocol_message}"
+          logger.debug "Calling NACK failure callbacks for #{message.class.name} - #{message.to_safe_json}, protocol message: #{protocol_message}"
           message.fail error
         end
-        logger.debug "Calling NACK failure callbacks for #{protocol_message.class.name} - #{protocol_message.to_json}"
+        logger.debug "Calling NACK failure callbacks for #{protocol_message.class.name} - #{protocol_message.to_safe_json}"
         protocol_message.fail error
       end
 

--- a/lib/ably/realtime/channel/channel_manager.rb
+++ b/lib/ably/realtime/channel/channel_manager.rb
@@ -58,7 +58,7 @@ module Ably::Realtime
       # all messages awaiting an ACK response should fail immediately
       def fail_messages_awaiting_ack(error)
         # Allow a short time for other queued operations to complete before failing all messages
-        EventMachine.add_timer(0.1) do
+        EventMachine.next_tick do
           error = Ably::Exceptions::MessageDeliveryFailed.new("Channel cannot publish messages whilst state is '#{channel.state}'") unless error
           fail_messages_in_queue connection.__pending_message_ack_queue__, error
           fail_messages_in_queue connection.__outgoing_message_queue__, error

--- a/lib/ably/realtime/client/incoming_message_dispatcher.rb
+++ b/lib/ably/realtime/client/incoming_message_dispatcher.rb
@@ -178,14 +178,14 @@ module Ably::Realtime
 
       def ack_messages(messages)
         messages.each do |message|
-          logger.debug "Calling ACK success callbacks for #{message.class.name} - #{message.to_json}"
+          logger.debug "Calling ACK success callbacks for #{message.class.name} - #{message.to_safe_json}"
           message.succeed message
         end
       end
 
       def nack_messages(messages, protocol_message)
         messages.each do |message|
-          logger.debug "Calling NACK failure callbacks for #{message.class.name} - #{message.to_json}, protocol message: #{protocol_message}"
+          logger.debug "Calling NACK failure callbacks for #{message.class.name} - #{message.to_safe_json}, protocol message: #{protocol_message}"
           message.fail protocol_message.error
         end
       end

--- a/lib/ably/realtime/presence/members_map.rb
+++ b/lib/ably/realtime/presence/members_map.rb
@@ -200,7 +200,7 @@ module Ably::Realtime
         return unless ensure_presence_message_is_valid(presence_message)
 
         unless should_update_member?(presence_message)
-          logger.debug "#{self.class.name}: Skipped presence member #{presence_message.action} on channel #{presence.channel.name}.\n#{presence_message.to_json}"
+          logger.debug "#{self.class.name}: Skipped presence member #{presence_message.action} on channel #{presence.channel.name}.\n#{presence_message.to_safe_json}"
           return
         end
 
@@ -239,13 +239,13 @@ module Ably::Realtime
       end
 
       def add_presence_member(presence_message)
-        logger.debug "#{self.class.name}: Member '#{presence_message.member_key}' for event '#{presence_message.action}' #{members.has_key?(presence_message.member_key) ? 'updated' : 'added'}.\n#{presence_message.to_json}"
+        logger.debug "#{self.class.name}: Member '#{presence_message.member_key}' for event '#{presence_message.action}' #{members.has_key?(presence_message.member_key) ? 'updated' : 'added'}.\n#{presence_message.to_safe_json}"
         members[presence_message.member_key] = { present: true, message: presence_message }
         presence.emit_message presence_message.action, presence_message
       end
 
       def remove_presence_member(presence_message)
-        logger.debug "#{self.class.name}: Member '#{presence_message.member_key}' removed.\n#{presence_message.to_json}"
+        logger.debug "#{self.class.name}: Member '#{presence_message.member_key}' removed.\n#{presence_message.to_safe_json}"
 
         if in_sync?
           members.delete presence_message.member_key

--- a/lib/ably/version.rb
+++ b/lib/ably/version.rb
@@ -1,5 +1,5 @@
 module Ably
-  VERSION = '0.8.14'
+  VERSION = '0.8.15'
   PROTOCOL_VERSION = '0.8'
 
   # Allow a variant to be configured for all instances of this client library

--- a/spec/acceptance/realtime/channel_spec.rb
+++ b/spec/acceptance/realtime/channel_spec.rb
@@ -373,7 +373,7 @@ describe Ably::Realtime::Channel, :event_machine do
             expect(message_id.uniq.count).to eql(1)
 
             # Check that messages use index 0,1,2 in the ID
-            message_indexes = messages.map { |msg| msg.id.split(':')[1] }
+            message_indexes = messages.map { |msg| msg.id.split(':').last }
             expect(message_indexes).to include("0", "1", "2")
             stop_reactor
           end

--- a/spec/acceptance/realtime/channel_spec.rb
+++ b/spec/acceptance/realtime/channel_spec.rb
@@ -92,12 +92,14 @@ describe Ably::Realtime::Channel, :event_machine do
 
         it 'reattaches' do
           channel.attach do
-            channel.transition_state_machine :failed, reason: RuntimeError.new
-            expect(channel).to be_failed
-            channel.attach do
-              expect(channel).to be_attached
-              stop_reactor
+            channel.once(:failed) do
+              expect(channel).to be_failed
+              channel.attach do
+                expect(channel).to be_attached
+                stop_reactor
+              end
             end
+            channel.transition_state_machine :failed, reason: RuntimeError.new
           end
         end
       end

--- a/spec/acceptance/realtime/presence_spec.rb
+++ b/spec/acceptance/realtime/presence_spec.rb
@@ -42,9 +42,11 @@ describe Ably::Realtime::Presence, :event_machine do
 
       def setup_test(method_name, args, options)
         if options[:enter_first]
-          presence_client_one.public_send(method_name.to_s.gsub(/leave|update/, 'enter'), args) do
+          presence_client_one.subscribe do
+            presence_client_one.unsubscribe
             yield
           end
+          presence_client_one.public_send(method_name.to_s.gsub(/leave|update/, 'enter'), args)
         else
           yield
         end
@@ -468,7 +470,14 @@ describe Ably::Realtime::Presence, :event_machine do
 
       context 'once server sync is complete' do
         it 'behaves like an Enumerable allowing direct access to current members' do
-          when_all(presence_client_one.enter, presence_client_two.enter) do
+          presence_client_one.enter
+          presence_client_two.enter
+
+          entered = 0
+          presence_client_one.subscribe(:enter) do
+            entered += 1
+            next unless entered == 2
+
             presence_anonymous_client.members.once(:in_sync) do
               expect(presence_anonymous_client.members.count).to eql(2)
               member_ids = presence_anonymous_client.members.map(&:member_key)
@@ -495,7 +504,10 @@ describe Ably::Realtime::Presence, :event_machine do
 
       context 'when attaching to a channel with members present' do
         it 'is false and the presence channel will subsequently be synced' do
-          presence_client_one.enter do
+          presence_client_one.enter
+          presence_client_one.subscribe(:enter) do
+            presence_client_one.unsubscribe :enter
+
             channel_anonymous_client.attach do
               expect(channel_anonymous_client.presence).to_not be_sync_complete
               channel_anonymous_client.presence.get(wait_for_sync: true) do
@@ -680,16 +692,18 @@ describe Ably::Realtime::Presence, :event_machine do
               it 'waits until sync is complete', em_timeout: 30 do # allow for slow connections and lots of messages
                 enter_expected_count.times do |index|
                   EventMachine.add_timer(index / 10) do
-                    presence_client_one.enter_client("client:#{index}") do |message|
-                      entered << message
-                      next unless entered.count == enter_expected_count
+                    presence_client_one.enter_client("client:#{index}")
+                  end
+                end
 
-                      presence_anonymous_client.get(wait_for_sync: true) do |members|
-                        expect(members.map(&:client_id).uniq.count).to eql(enter_expected_count)
-                        expect(members.count).to eql(enter_expected_count)
-                        stop_reactor
-                      end
-                    end
+                presence_client_one.subscribe(:enter) do |message|
+                  entered << message
+                  next unless entered.count == enter_expected_count
+
+                  presence_anonymous_client.get(wait_for_sync: true) do |members|
+                    expect(members.map(&:client_id).uniq.count).to eql(enter_expected_count)
+                    expect(members.count).to eql(enter_expected_count)
+                    stop_reactor
                   end
                 end
               end
@@ -697,19 +711,21 @@ describe Ably::Realtime::Presence, :event_machine do
 
             context 'by default' do
               it 'it does not wait for sync', em_timeout: 30 do # allow for slow connections and lots of messages
-                enter_expected_count.times do |index|
-                  EventMachine.add_timer(index / 10) do
-                    presence_client_one.enter_client("client:#{index}") do |message|
-                      entered << message
-                      next unless entered.count == enter_expected_count
+                enter_expected_count.times do |indx|
+                  EventMachine.add_timer(indx / 10) do
+                    presence_client_one.enter_client "client:#{indx}"
+                  end
+                end
 
-                      channel_anonymous_client.attach do
-                        presence_anonymous_client.get do |members|
-                          expect(presence_anonymous_client.members).to_not be_in_sync
-                          expect(members.count).to eql(0)
-                          stop_reactor
-                        end
-                      end
+                presence_client_one.subscribe(:enter) do |message|
+                  entered << message
+                  next unless entered.count == enter_expected_count
+
+                  channel_anonymous_client.attach do
+                    presence_anonymous_client.get do |members|
+                      expect(presence_anonymous_client.members).to_not be_in_sync
+                      expect(members.count).to eql(0)
+                      stop_reactor
                     end
                   end
                 end
@@ -896,15 +912,25 @@ describe Ably::Realtime::Presence, :event_machine do
 
         context 'and sync is complete' do
           it 'does not cache members that have left' do
-            presence_client_one.enter enter_data do
+            enter_ack = false
+
+            presence_client_one.subscribe(:enter) do
+              presence_client_one.unsubscribe :enter
+
               expect(presence_client_one.members).to be_in_sync
               expect(presence_client_one.members.send(:members).count).to eql(1)
               presence_client_one.leave data
             end
 
+            presence_client_one.enter(enter_data) do
+              enter_ack = true
+            end
+
             presence_client_one.subscribe(:leave) do |presence_message|
+              presence_client_one.unsubscribe :leave
               expect(presence_message.data).to eql(data)
               expect(presence_client_one.members.send(:members).count).to eql(0)
+              expect(enter_ack).to eql(true)
               stop_reactor
             end
           end
@@ -1290,7 +1316,9 @@ describe Ably::Realtime::Presence, :event_machine do
       # skip 'it fails if the connection changes to failed state'
 
       it 'returns the current members on the channel' do
-        presence_client_one.enter do
+        presence_client_one.enter
+        presence_client_one.subscribe(:enter) do
+          presence_client_one.unsubscribe :enter
           presence_client_one.get do |members|
             expect(members.count).to eq(1)
 
@@ -1351,7 +1379,10 @@ describe Ably::Realtime::Presence, :event_machine do
       end
 
       it 'does not wait for SYNC to complete if :wait_for_sync option is false' do
-        presence_client_one.enter do
+        presence_client_one.enter
+        presence_client_one.subscribe(:enter) do
+          presence_client_one.unsubscribe :enter
+
           presence_client_two.get(wait_for_sync: false) do |members|
             expect(members.count).to eql(0)
             stop_reactor
@@ -1362,11 +1393,13 @@ describe Ably::Realtime::Presence, :event_machine do
       context 'when a member enters and then leaves' do
         it 'has no members' do
           presence_client_one.enter do
-            presence_client_one.leave do
-              presence_client_one.get do |members|
-                expect(members.count).to eq(0)
-                stop_reactor
-              end
+            presence_client_one.leave
+          end
+
+          presence_client_one.subscribe(:leave) do
+            presence_client_one.get do |members|
+              expect(members.count).to eq(0)
+              stop_reactor
             end
           end
         end
@@ -1524,7 +1557,10 @@ describe Ably::Realtime::Presence, :event_machine do
 
     context 'REST #get' do
       it 'returns current members' do
-        presence_client_one.enter(data_payload) do
+        presence_client_one.enter data_payload
+        presence_client_one.subscribe(:enter) do
+          presence_client_one.unsubscribe :enter
+
           members_page = channel_rest_client_one.presence.get
           this_member = members_page.items.first
 
@@ -1538,7 +1574,10 @@ describe Ably::Realtime::Presence, :event_machine do
 
       it 'returns no members once left' do
         presence_client_one.enter(data_payload) do
-          presence_client_one.leave do
+          presence_client_one.leave
+          presence_client_one.subscribe(:leave) do
+            presence_client_one.unsubscribe :leave
+
             members_page = channel_rest_client_one.presence.get
             expect(members_page.items.count).to eql(0)
             stop_reactor
@@ -1654,7 +1693,8 @@ describe Ably::Realtime::Presence, :event_machine do
 
       context '#get' do
         it 'returns a list of members with decrypted data' do
-          encrypted_channel.presence.enter(data) do
+          encrypted_channel.presence.enter(data)
+          encrypted_channel.presence.subscribe(:enter) do
             encrypted_channel.presence.get do |members|
               member = members.first
               expect(member.encoding).to be_nil
@@ -1667,7 +1707,8 @@ describe Ably::Realtime::Presence, :event_machine do
 
       context 'REST #get' do
         it 'returns a list of members with decrypted data' do
-          encrypted_channel.presence.enter(data) do
+          encrypted_channel.presence.enter(data)
+          encrypted_channel.presence.subscribe(:enter) do
             member = channel_rest_client_one.presence.get.items.first
             expect(member.encoding).to be_nil
             expect(member.data).to eql(data)
@@ -1738,7 +1779,7 @@ describe Ably::Realtime::Presence, :event_machine do
     context 'connection failure mid-way through a large member sync' do
       let(:members_count) { 250 }
       let(:sync_pages_received) { [] }
-      let(:client_options)  { default_options.merge(log_level: :error) }
+      let(:client_options)  { default_options.merge(log_level: :fatal) }
 
       it 'resumes the SYNC operation', em_timeout: 15 do
         when_all(*members_count.times.map do |index|

--- a/spec/acceptance/rest/channel_spec.rb
+++ b/spec/acceptance/rest/channel_spec.rb
@@ -360,10 +360,7 @@ describe Ably::Rest::Channel do
       let(:channel_name) { "persisted:#{random_str(4)}" }
       let(:channel) { client.channel(channel_name) }
       let(:endpoint) do
-        client.endpoint.tap do |client_end_point|
-          client_end_point.user = key_name
-          client_end_point.password = key_secret
-        end
+        client.endpoint
       end
       let(:default_history_options) do
           {
@@ -378,6 +375,7 @@ describe Ably::Rest::Channel do
             query_params = default_history_options
             .merge(option => milliseconds).map { |k, v| "#{k}=#{v}" }.join('&')
             stub_request(:get, "#{endpoint}/channels/#{Addressable::URI.encode(channel_name)}/messages?#{query_params}").
+              with(basic_auth: [key_name, key_secret]).
               to_return(:body => '{}', :headers => { 'Content-Type' => 'application/json' })
           }
 

--- a/spec/acceptance/rest/client_spec.rb
+++ b/spec/acceptance/rest/client_spec.rb
@@ -111,7 +111,8 @@ describe Ably::Rest::Client do
           let(:client_options)      { default_options.merge(key: api_key) }
 
           let!(:get_message_history_stub) do
-            stub_request(:get, "https://#{api_key}@#{environment}-#{Ably::Rest::Client::DOMAIN}/channels/#{channel_name}/messages?#{history_querystring}").
+            stub_request(:get, "https://#{environment}-#{Ably::Rest::Client::DOMAIN}/channels/#{channel_name}/messages?#{history_querystring}").
+              with(basic_auth: [key_name, key_secret]).
               to_return(body: [], headers: { 'Content-Type' => 'application/json' })
           end
 
@@ -284,7 +285,9 @@ describe Ably::Rest::Client do
       context 'when environment is NOT production' do
         let(:client_options) { default_options.merge(environment: 'sandbox', key: api_key) }
         let!(:default_host_request_stub) do
-          stub_request(:post, "https://#{api_key}@#{environment}-#{Ably::Rest::Client::DOMAIN}#{path}").to_return do
+          stub_request(:post, "https://#{environment}-#{Ably::Rest::Client::DOMAIN}#{path}").
+            with(basic_auth: [key_name, key_secret]).
+            to_return do
             raise Faraday::TimeoutError.new('timeout error message')
           end
         end
@@ -313,16 +316,16 @@ describe Ably::Rest::Client do
         end
 
         let!(:first_fallback_request_stub) do
-          stub_request(:post, "https://#{api_key}@#{custom_hosts[0]}#{path}").to_return(&fallback_block)
+          stub_request(:post, "https://#{custom_hosts[0]}#{path}").with(basic_auth: [key_name, key_secret]).to_return(&fallback_block)
         end
 
         let!(:second_fallback_request_stub) do
-          stub_request(:post, "https://#{api_key}@#{custom_hosts[1]}#{path}").to_return(&fallback_block)
+          stub_request(:post, "https://#{custom_hosts[1]}#{path}").with(basic_auth: [key_name, key_secret]).to_return(&fallback_block)
         end
 
         context 'and connection times out' do
           let!(:default_host_request_stub) do
-            stub_request(:post, "https://#{api_key}@#{Ably::Rest::Client::DOMAIN}#{path}").to_return do
+            stub_request(:post, "https://#{Ably::Rest::Client::DOMAIN}#{path}").with(basic_auth: [key_name, key_secret]).to_return do
               raise Faraday::TimeoutError.new('timeout error message')
             end
           end
@@ -336,7 +339,7 @@ describe Ably::Rest::Client do
 
           context "and the total request time exeeds #{http_defaults.fetch(:max_retry_duration)} seconds" do
             let!(:default_host_request_stub) do
-              stub_request(:post, "https://#{api_key}@#{Ably::Rest::Client::DOMAIN}#{path}").to_return do
+              stub_request(:post, "https://#{Ably::Rest::Client::DOMAIN}#{path}").with(basic_auth: [key_name, key_secret]).to_return do
                 sleep max_retry_duration * 1.5
                 raise Faraday::TimeoutError.new('timeout error message')
               end
@@ -353,7 +356,7 @@ describe Ably::Rest::Client do
 
         context 'and connection fails' do
           let!(:default_host_request_stub) do
-            stub_request(:post, "https://#{api_key}@#{Ably::Rest::Client::DOMAIN}#{path}").to_return do
+            stub_request(:post, "https://#{Ably::Rest::Client::DOMAIN}#{path}").with(basic_auth: [key_name, key_secret]).to_return do
               raise Faraday::ConnectionFailed.new('connection failure error message')
             end
           end
@@ -369,7 +372,7 @@ describe Ably::Rest::Client do
         context 'and basic authentication fails' do
           let(:status) { 401 }
           let!(:default_host_request_stub) do
-            stub_request(:post, "https://#{api_key}@#{Ably::Rest::Client::DOMAIN}#{path}").to_return(
+            stub_request(:post, "https://#{Ably::Rest::Client::DOMAIN}#{path}").with(basic_auth: [key_name, key_secret]).to_return(
               headers: { 'Content-Type' => 'application/json' },
               status: status,
               body: {
@@ -401,7 +404,7 @@ describe Ably::Rest::Client do
             end
           end
           let!(:default_host_request_stub) do
-            stub_request(:post, "https://#{api_key}@#{Ably::Rest::Client::DOMAIN}#{path}").to_return(&fallback_block)
+            stub_request(:post, "https://#{Ably::Rest::Client::DOMAIN}#{path}").with(basic_auth: [key_name, key_secret]).to_return(&fallback_block)
           end
 
           it 'attempts the fallback hosts as this is an authentication failure' do
@@ -437,20 +440,20 @@ describe Ably::Rest::Client do
           end
         end
         let!(:default_host_request_stub) do
-          stub_request(:post, "https://#{api_key}@#{Ably::Rest::Client::DOMAIN}#{path}").to_return(&fallback_block)
+          stub_request(:post, "https://#{Ably::Rest::Client::DOMAIN}#{path}").with(basic_auth: [key_name, key_secret]).to_return(&fallback_block)
         end
 
         context 'with custom fallback hosts provided' do
           let!(:first_fallback_request_stub) do
-            stub_request(:post, "https://#{api_key}@#{custom_hosts[0]}#{path}").to_return(&fallback_block)
+            stub_request(:post, "https://#{custom_hosts[0]}#{path}").with(basic_auth: [key_name, key_secret]).to_return(&fallback_block)
           end
 
           let!(:second_fallback_request_stub) do
-            stub_request(:post, "https://#{api_key}@#{custom_hosts[1]}#{path}").to_return(&fallback_block)
+            stub_request(:post, "https://#{custom_hosts[1]}#{path}").with(basic_auth: [key_name, key_secret]).to_return(&fallback_block)
           end
 
           let(:client_options) {
-            production_options.merge(fallback_hosts: custom_hosts)
+            production_options.merge(fallback_hosts: custom_hosts, log_level: :error)
           }
 
           it 'attempts the fallback hosts as this is an authentication failure (#RSC15b, #TO3k6)' do
@@ -516,7 +519,8 @@ describe Ably::Rest::Client do
                   port: port,
                   tls: false,
                   http_request_timeout: request_timeout,
-                  max_retry_duration: request_timeout * 3
+                  max_retry_duration: request_timeout * 3,
+                  log_level: :error
                 )
               end
               let(:fail_fallback_request_count) { 1 }
@@ -619,16 +623,16 @@ describe Ably::Rest::Client do
           end
         end
         let!(:default_host_request_stub) do
-          stub_request(:post, "https://#{api_key}@#{env}-#{Ably::Rest::Client::DOMAIN}#{path}").to_return(&fallback_block)
+          stub_request(:post, "https://#{env}-#{Ably::Rest::Client::DOMAIN}#{path}").with(basic_auth: [key_name, key_secret]).to_return(&fallback_block)
         end
 
         context 'with custom fallback hosts provided (#RSC15b, #TO3k6)' do
           let!(:first_fallback_request_stub) do
-            stub_request(:post, "https://#{api_key}@#{custom_hosts[0]}#{path}").to_return(&fallback_block)
+            stub_request(:post, "https://#{custom_hosts[0]}#{path}").with(basic_auth: [key_name, key_secret]).to_return(&fallback_block)
           end
 
           let!(:second_fallback_request_stub) do
-            stub_request(:post, "https://#{api_key}@#{custom_hosts[1]}#{path}").to_return(&fallback_block)
+            stub_request(:post, "https://#{custom_hosts[1]}#{path}").with(basic_auth: [key_name, key_secret]).to_return(&fallback_block)
           end
 
           let(:client_options) {
@@ -666,11 +670,11 @@ describe Ably::Rest::Client do
           }
 
           let!(:first_fallback_request_stub) do
-            stub_request(:post, "https://#{api_key}@#{Ably::FALLBACK_HOSTS[0]}#{path}").to_return(&fallback_block)
+            stub_request(:post, "https://#{Ably::FALLBACK_HOSTS[0]}#{path}").with(basic_auth: [key_name, key_secret]).to_return(&fallback_block)
           end
 
           let!(:second_fallback_request_stub) do
-            stub_request(:post, "https://#{api_key}@#{Ably::FALLBACK_HOSTS[1]}#{path}").to_return(&fallback_block)
+            stub_request(:post, "https://#{Ably::FALLBACK_HOSTS[1]}#{path}").with(basic_auth: [key_name, key_secret]).to_return(&fallback_block)
           end
 
           let(:client_options) {
@@ -701,7 +705,7 @@ describe Ably::Rest::Client do
           let(:path) { '/channels/test/publish' }
 
           let!(:custom_host_request_stub) do
-            stub_request(:post, "https://#{api_key}@#{custom_host}#{path}").to_return do
+            stub_request(:post, "https://#{custom_host}#{path}").with(basic_auth: [key_name, key_secret]).to_return do
               raise Faraday::ConnectionFailed.new('connection failure error message')
             end
           end
@@ -840,11 +844,12 @@ describe Ably::Rest::Client do
             lib << Ably::VERSION
 
 
-            stub_request(:post, "#{client.endpoint.to_s.gsub('://', "://#{api_key}@")}/channels/foo/publish").
+            stub_request(:post, "#{client.endpoint.to_s.gsub('://', "://")}/channels/foo/publish").
               with(headers: {
                 'X-Ably-Version' => Ably::PROTOCOL_VERSION,
                 'X-Ably-Lib' => lib.join('-')
               }).
+              with(basic_auth: [key_name, key_secret]).
               to_return(status: 201, body: '{}', headers: { 'Content-Type' => 'application/json' })
           end
 

--- a/spec/acceptance/rest/presence_spec.rb
+++ b/spec/acceptance/rest/presence_spec.rb
@@ -69,14 +69,12 @@ describe Ably::Rest::Presence do
             }
           end
           let(:endpoint) do
-            client.endpoint.tap do |client_end_point|
-              client_end_point.user = key_name
-              client_end_point.password = key_secret
-            end
+            client.endpoint
           end
           let!(:get_stub) {
             query_params = query_options.map { |k, v| "#{k}=#{v}" }.join('&')
             stub_request(:get, "#{endpoint}/channels/#{Addressable::URI.encode(channel_name)}/presence?#{query_params}").
+              with(basic_auth: [key_name, key_secret]).
               to_return(:body => '{}', :headers => { 'Content-Type' => 'application/json' })
           }
           let(:channel_name) { random_str }
@@ -182,10 +180,7 @@ describe Ably::Rest::Presence do
         let(:user) { 'appid.keyuid' }
         let(:secret) { random_str(8) }
         let(:endpoint) do
-          client.endpoint.tap do |client_end_point|
-            client_end_point.user = user
-            client_end_point.password = secret
-          end
+          client.endpoint
         end
         let(:client) do
           Ably::Rest::Client.new(key: "#{user}:#{secret}")
@@ -201,6 +196,7 @@ describe Ably::Rest::Presence do
           let!(:history_stub) {
             query_params = history_options.map { |k, v| "#{k}=#{v}" }.join('&')
             stub_request(:get, "#{endpoint}/channels/#{Addressable::URI.encode(channel_name)}/presence/history?#{query_params}").
+              with(basic_auth: [user, secret]).
               to_return(:body => '{}', :headers => { 'Content-Type' => 'application/json' })
           }
 
@@ -241,6 +237,7 @@ describe Ably::Rest::Presence do
               let!(:history_stub) {
                 query_params = history_options.map { |k, v| "#{k}=#{v}" }.join('&')
                 stub_request(:get, "#{endpoint}/channels/#{Addressable::URI.encode(channel_name)}/presence/history?#{query_params}").
+                  with(basic_auth: [user, secret]).
                   to_return(:body => '{}', :headers => { 'Content-Type' => 'application/json' })
               }
 
@@ -310,10 +307,7 @@ describe Ably::Rest::Presence do
       let(:user) { 'appid.keyuid' }
       let(:secret) { random_str(8) }
       let(:endpoint) do
-        client.endpoint.tap do |client_end_point|
-          client_end_point.user = user
-          client_end_point.password = secret
-        end
+        client.endpoint
       end
       let(:client) do
         Ably::Rest::Client.new(client_options.merge(key: "#{user}:#{secret}"))
@@ -348,6 +342,7 @@ describe Ably::Rest::Presence do
         context '#get' do
           let!(:get_stub)   {
             stub_request(:get, "#{endpoint}/channels/#{Addressable::URI.encode(channel_name)}/presence?limit=100").
+              with(basic_auth: [user, secret]).
               to_return(:body => serialized_encoded_message, :headers => { 'Content-Type' => content_type })
           }
 
@@ -365,6 +360,7 @@ describe Ably::Rest::Presence do
         context '#history' do
           let!(:history_stub)   {
             stub_request(:get, "#{endpoint}/channels/#{Addressable::URI.encode(channel_name)}/presence/history?direction=backwards&limit=100").
+              with(basic_auth: [user, secret]).
               to_return(:body => serialized_encoded_message, :headers => { 'Content-Type' => content_type })
           }
 
@@ -395,6 +391,7 @@ describe Ably::Rest::Presence do
           let(:client_options) { default_options.merge(log_level: :fatal) }
           let!(:get_stub)   {
             stub_request(:get, "#{endpoint}/channels/#{Addressable::URI.encode(channel_name)}/presence?limit=100").
+              with(basic_auth: [user, secret]).
               to_return(:body => serialized_encoded_message_with_invalid_encoding, :headers => { 'Content-Type' => content_type })
           }
           let(:presence_message) { presence.get.items.first }
@@ -419,6 +416,7 @@ describe Ably::Rest::Presence do
           let(:client_options) { default_options.merge(log_level: :fatal) }
           let!(:history_stub)   {
             stub_request(:get, "#{endpoint}/channels/#{Addressable::URI.encode(channel_name)}/presence/history?direction=backwards&limit=100").
+              with(basic_auth: [user, secret]).
               to_return(:body => serialized_encoded_message_with_invalid_encoding, :headers => { 'Content-Type' => content_type })
           }
           let(:presence_message) { presence.history.items.first }

--- a/spec/unit/realtime/presence_spec.rb
+++ b/spec/unit/realtime/presence_spec.rb
@@ -49,13 +49,13 @@ describe Ably::Realtime::Presence do
     let(:message_history) { Hash.new { |hash, key| hash[key] = 0 } }
     let(:enter_action) { Ably::Models::PresenceMessage::ACTION.Enter }
     let(:enter_message) do
-      instance_double('Ably::Models::PresenceMessage', action: enter_action, connection_id: random_str, decode: true, member_key: random_str)
+      instance_double('Ably::Models::PresenceMessage', action: enter_action, connection_id: random_str, decode: true, member_key: random_str, to_safe_json: true)
     end
     let(:leave_message) do
-      instance_double('Ably::Models::PresenceMessage', action: Ably::Models::PresenceMessage::ACTION.Leave, connection_id: random_str, decode: true, member_key: random_str)
+      instance_double('Ably::Models::PresenceMessage', action: Ably::Models::PresenceMessage::ACTION.Leave, connection_id: random_str, decode: true, member_key: random_str, to_safe_json: true)
     end
     let(:update_message) do
-      instance_double('Ably::Models::PresenceMessage', action: Ably::Models::PresenceMessage::ACTION.Update, connection_id: random_str, decode: true, member_key: random_str)
+      instance_double('Ably::Models::PresenceMessage', action: Ably::Models::PresenceMessage::ACTION.Update, connection_id: random_str, decode: true, member_key: random_str, to_safe_json: true)
     end
 
     context '#subscribe' do


### PR DESCRIPTION
@paddybyers this PR fixes some timing issues with 0.8 that now failed with the new 1.0 realtime system. 

I incorrectly assumed messages always came before ACKs, but this is no longer the case. This ensures we remove that assumption