### PR TITLE
Channel name encoding error for REST requests

### DIFF
--- a/lib/ably/rest/channel.rb
+++ b/lib/ably/rest/channel.rb
@@ -130,7 +130,7 @@ module Ably
 
       private
       def base_path
-        "/channels/#{Addressable::URI.encode(name)}"
+        "/channels/#{URI.encode_www_form_component(name)}"
       end
 
       def decode_message(message)

--- a/lib/ably/rest/presence.rb
+++ b/lib/ably/rest/presence.rb
@@ -84,7 +84,7 @@ module Ably
 
       private
       def base_path
-        "/channels/#{Addressable::URI.encode(channel.name)}/presence"
+        "/channels/#{URI.encode_www_form_component(channel.name)}/presence"
       end
 
       def decode_message(presence_message)

--- a/spec/acceptance/rest/channel_spec.rb
+++ b/spec/acceptance/rest/channel_spec.rb
@@ -374,7 +374,7 @@ describe Ably::Rest::Channel do
           let!(:history_stub) {
             query_params = default_history_options
             .merge(option => milliseconds).map { |k, v| "#{k}=#{v}" }.join('&')
-            stub_request(:get, "#{endpoint}/channels/#{Addressable::URI.encode(channel_name)}/messages?#{query_params}").
+            stub_request(:get, "#{endpoint}/channels/#{URI.encode_www_form_component(channel_name)}/messages?#{query_params}").
               to_return(:body => '{}', :headers => { 'Content-Type' => 'application/json' })
           }
 

--- a/spec/acceptance/rest/channel_spec.rb
+++ b/spec/acceptance/rest/channel_spec.rb
@@ -256,6 +256,25 @@ describe Ably::Rest::Channel do
           end
         end
       end
+
+      context 'with a non ASCII channel name' do
+        let(:channel_name) { 'foo:¡€≤`☃' }
+        let(:channel_name_encoded) { 'foo%3A%C2%A1%E2%82%AC%E2%89%A4%60%E2%98%83' }
+        let(:endpoint) { client.endpoint }
+        let(:channel) { client.channels.get(channel_name) }
+
+        context 'stubbed', :webmock do
+          let!(:get_stub) {
+            stub_request(:post, "#{endpoint}/channels/#{channel_name_encoded}/publish").
+              to_return(:body => '{}', :headers => { 'Content-Type' => 'application/json' })
+          }
+
+          it 'correctly encodes the channel name' do
+            channel.publish('foo')
+            expect(get_stub).to have_been_requested
+          end
+        end
+      end
     end
 
     describe '#history' do

--- a/spec/acceptance/rest/presence_spec.rb
+++ b/spec/acceptance/rest/presence_spec.rb
@@ -73,7 +73,7 @@ describe Ably::Rest::Presence do
           end
           let!(:get_stub) {
             query_params = query_options.map { |k, v| "#{k}=#{v}" }.join('&')
-            stub_request(:get, "#{endpoint}/channels/#{Addressable::URI.encode(channel_name)}/presence?#{query_params}").
+            stub_request(:get, "#{endpoint}/channels/#{URI.encode_www_form_component(channel_name)}/presence?#{query_params}").
               to_return(:body => '{}', :headers => { 'Content-Type' => 'application/json' })
           }
           let(:channel_name) { random_str }
@@ -194,7 +194,7 @@ describe Ably::Rest::Presence do
         context 'limit options', :webmock do
           let!(:history_stub) {
             query_params = history_options.map { |k, v| "#{k}=#{v}" }.join('&')
-            stub_request(:get, "#{endpoint}/channels/#{Addressable::URI.encode(channel_name)}/presence/history?#{query_params}").
+            stub_request(:get, "#{endpoint}/channels/#{URI.encode_www_form_component(channel_name)}/presence/history?#{query_params}").
               to_return(:body => '{}', :headers => { 'Content-Type' => 'application/json' })
           }
 
@@ -234,7 +234,7 @@ describe Ably::Rest::Presence do
               }
               let!(:history_stub) {
                 query_params = history_options.map { |k, v| "#{k}=#{v}" }.join('&')
-                stub_request(:get, "#{endpoint}/channels/#{Addressable::URI.encode(channel_name)}/presence/history?#{query_params}").
+                stub_request(:get, "#{endpoint}/channels/#{URI.encode_www_form_component(channel_name)}/presence/history?#{query_params}").
                   to_return(:body => '{}', :headers => { 'Content-Type' => 'application/json' })
               }
 
@@ -338,7 +338,7 @@ describe Ably::Rest::Presence do
 
         context '#get' do
           let!(:get_stub)   {
-            stub_request(:get, "#{endpoint}/channels/#{Addressable::URI.encode(channel_name)}/presence?limit=100").
+            stub_request(:get, "#{endpoint}/channels/#{URI.encode_www_form_component(channel_name)}/presence?limit=100").
               to_return(:body => serialized_encoded_message, :headers => { 'Content-Type' => content_type })
           }
 
@@ -355,7 +355,7 @@ describe Ably::Rest::Presence do
 
         context '#history' do
           let!(:history_stub)   {
-            stub_request(:get, "#{endpoint}/channels/#{Addressable::URI.encode(channel_name)}/presence/history?direction=backwards&limit=100").
+            stub_request(:get, "#{endpoint}/channels/#{URI.encode_www_form_component(channel_name)}/presence/history?direction=backwards&limit=100").
               to_return(:body => serialized_encoded_message, :headers => { 'Content-Type' => content_type })
           }
 
@@ -385,7 +385,7 @@ describe Ably::Rest::Presence do
         context '#get' do
           let(:client_options) { default_options.merge(log_level: :fatal) }
           let!(:get_stub)   {
-            stub_request(:get, "#{endpoint}/channels/#{Addressable::URI.encode(channel_name)}/presence?limit=100").
+            stub_request(:get, "#{endpoint}/channels/#{URI.encode_www_form_component(channel_name)}/presence?limit=100").
               to_return(:body => serialized_encoded_message_with_invalid_encoding, :headers => { 'Content-Type' => content_type })
           }
           let(:presence_message) { presence.get.items.first }
@@ -409,7 +409,7 @@ describe Ably::Rest::Presence do
         context '#history' do
           let(:client_options) { default_options.merge(log_level: :fatal) }
           let!(:history_stub)   {
-            stub_request(:get, "#{endpoint}/channels/#{Addressable::URI.encode(channel_name)}/presence/history?direction=backwards&limit=100").
+            stub_request(:get, "#{endpoint}/channels/#{URI.encode_www_form_component(channel_name)}/presence/history?direction=backwards&limit=100").
               to_return(:body => serialized_encoded_message_with_invalid_encoding, :headers => { 'Content-Type' => content_type })
           }
           let(:presence_message) { presence.history.items.first }

--- a/spec/acceptance/rest/presence_spec.rb
+++ b/spec/acceptance/rest/presence_spec.rb
@@ -111,6 +111,25 @@ describe Ably::Rest::Presence do
             expect(fixtures_channel.presence.get(connection_id: 'does.not.exist').items).to be_empty
           end
         end
+
+        context 'with a non ASCII channel name' do
+          let(:channel_name) { 'foo:¡€≤`☃' }
+          let(:channel_name_encoded) { 'foo%3A%C2%A1%E2%82%AC%E2%89%A4%60%E2%98%83' }
+          let(:endpoint) { client.endpoint }
+          let(:channel) { client.channels.get(channel_name) }
+
+          context 'stubbed', :webmock do
+            let!(:get_stub) {
+              stub_request(:get, "#{endpoint}/channels/#{channel_name_encoded}/presence?limit=100").
+                to_return(:body => '{}', :headers => { 'Content-Type' => 'application/json' })
+            }
+
+            it 'correctly encodes the channel name' do
+              channel.presence.get
+              expect(get_stub).to have_been_requested
+            end
+          end
+        end
       end
 
       describe '#history' do


### PR DESCRIPTION
This PR is just [@smeyfroi's PR](https://github.com/ably/ably-ruby/pull/118) plus one additional test to prevent a regression.

