### PR TITLE
Match signature of as_json in base class

### DIFF
--- a/lib/ably/exceptions.rb
+++ b/lib/ably/exceptions.rb
@@ -39,7 +39,7 @@ module Ably
         message.join(' ')
       end
 
-      def as_json
+      def as_json(*)
         {
           message: "#{self.class}: #{message}",
           status: @status,


### PR DESCRIPTION
Avoids error below:
```
irb(main):001:0> e=Ably::Exceptions::BaseAblyException.new('test')
=> #<Ably::Exceptions::BaseAblyException: test>
irb(main):002:0> e.to_json
ArgumentError: wrong number of arguments (given 1, expected 0)
	from /home/vagrant/.bundler/ruby/2.3.0/bundler/gems/ably-ruby-e7372296474a/lib/ably/exceptions.rb:42:in `as_json'
	from /home/vagrant/.bundler/ruby/2.3.0/gems/activesupport-5.0.2/lib/active_support/json/encoding.rb:33:in `encode'
	from /home/vagrant/.bundler/ruby/2.3.0/gems/activesupport-5.0.2/lib/active_support/json/encoding.rb:20:in `encode'
	from /home/vagrant/.bundler/ruby/2.3.0/gems/activesupport-5.0.2/lib/active_support/core_ext/object/json.rb:37:in `to_json'
```

With fix:
```
irb(main):001:0> e=Ably::Exceptions::BaseAblyException.new('test')
=> #<Ably::Exceptions::BaseAblyException: test>
irb(main):002:0> e.to_json
=> "{\"message\":\"Ably::Exceptions::BaseAblyException: test\"}"
```