### PR TITLE
Add Ruby 2.1 and 2.3 to Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1.10
   - 2.2.0
+  - 2.3.6
   - 2.4.1
 script: bundle exec rspec
 notifications:


### PR DESCRIPTION
Fix #129 