### PR TITLE
Do not encode strings in-place

### DIFF
--- a/lib/ably/auth.rb
+++ b/lib/ably/auth.rb
@@ -82,7 +82,7 @@ module Ably
 
       if has_client_id? && !token_creatable_externally? && !token_option
         raise ArgumentError, 'client_id cannot be provided without a complete API key or means to authenticate. An API key is needed to automatically authenticate with Ably and obtain a token' unless api_key_present?
-        ensure_utf_8 :client_id, client_id
+        client_id = ensure_utf_8 :client_id, client_id
       end
 
       # If a token details object or token string is provided in the initializer

--- a/lib/ably/auth.rb
+++ b/lib/ably/auth.rb
@@ -82,7 +82,7 @@ module Ably
 
       if has_client_id? && !token_creatable_externally? && !token_option
         raise ArgumentError, 'client_id cannot be provided without a complete API key or means to authenticate. An API key is needed to automatically authenticate with Ably and obtain a token' unless api_key_present?
-        client_id = ensure_utf_8 :client_id, client_id
+        client_id = ensure_utf_8(:client_id, client_id)
       end
 
       # If a token details object or token string is provided in the initializer

--- a/lib/ably/models/message.rb
+++ b/lib/ably/models/message.rb
@@ -62,9 +62,9 @@ module Ably::Models
 
       set_attributes_object attributes
 
-      ensure_utf_8 :name,      name,      allow_nil: true
-      ensure_utf_8 :client_id, client_id, allow_nil: true
-      ensure_utf_8 :encoding,  encoding,  allow_nil: true
+      name      = ensure_utf_8 :name,      name,      allow_nil: true
+      client_id = ensure_utf_8 :client_id, client_id, allow_nil: true
+      encoding  = ensure_utf_8 :encoding,  encoding,  allow_nil: true
     end
 
     %w( name client_id encoding ).each do |attribute|

--- a/lib/ably/models/message.rb
+++ b/lib/ably/models/message.rb
@@ -62,9 +62,9 @@ module Ably::Models
 
       set_attributes_object attributes
 
-      name      = ensure_utf_8 :name,      name,      allow_nil: true
-      client_id = ensure_utf_8 :client_id, client_id, allow_nil: true
-      encoding  = ensure_utf_8 :encoding,  encoding,  allow_nil: true
+      name      = ensure_utf_8(:name,      name,      allow_nil: true)
+      client_id = ensure_utf_8(:client_id, client_id, allow_nil: true)
+      encoding  = ensure_utf_8(:encoding,  encoding,  allow_nil: true)
     end
 
     %w( name client_id encoding ).each do |attribute|

--- a/lib/ably/models/presence_message.rb
+++ b/lib/ably/models/presence_message.rb
@@ -69,9 +69,9 @@ module Ably::Models
 
       set_attributes_object attributes
 
-      client_id     = ensure_utf_8 :client_id,     client_id,     allow_nil: true
-      connection_id = ensure_utf_8 :connection_id, connection_id, allow_nil: true
-      encoding      = ensure_utf_8 :encoding,      encoding,      allow_nil: true
+      client_id     = ensure_utf_8(:client_id,     client_id,     allow_nil: true)
+      connection_id = ensure_utf_8(:connection_id, connection_id, allow_nil: true)
+      encoding      = ensure_utf_8(:encoding,      encoding,      allow_nil: true)
     end
 
     %w( client_id data encoding ).each do |attribute|

--- a/lib/ably/models/presence_message.rb
+++ b/lib/ably/models/presence_message.rb
@@ -69,9 +69,9 @@ module Ably::Models
 
       set_attributes_object attributes
 
-      ensure_utf_8 :client_id,     client_id,     allow_nil: true
-      ensure_utf_8 :connection_id, connection_id, allow_nil: true
-      ensure_utf_8 :encoding,      encoding,      allow_nil: true
+      client_id     = ensure_utf_8 :client_id,     client_id,     allow_nil: true
+      connection_id = ensure_utf_8 :connection_id, connection_id, allow_nil: true
+      encoding      = ensure_utf_8 :encoding,      encoding,      allow_nil: true
     end
 
     %w( client_id data encoding ).each do |attribute|

--- a/lib/ably/modules/conversions.rb
+++ b/lib/ably/modules/conversions.rb
@@ -96,7 +96,8 @@ module Ably::Modules
       unless options[:allow_nil] && string_value.nil?
         raise ArgumentError, "#{field_name} must be a String" unless string_value.kind_of?(String)
       end
-      string_value.encode!(Encoding::UTF_8) if string_value
+      return string_value.encode(Encoding::UTF_8) if string_value
+      string_value
     rescue Encoding::UndefinedConversionError, Encoding::InvalidByteSequenceError => e
       raise ArgumentError, "#{field_name} could not be converted to UTF-8: #{e.message}"
     end

--- a/lib/ably/realtime/channel.rb
+++ b/lib/ably/realtime/channel.rb
@@ -93,7 +93,7 @@ module Ably
       # @option channel_options [Hash,Ably::Models::CipherParams]   :cipher   A hash of options or a {Ably::Models::CipherParams} to configure the encryption. *:key* is required, all other options are optional.  See {Ably::Util::Crypto#initialize} for a list of +:cipher+ options
       #
       def initialize(client, name, channel_options = {})
-        ensure_utf_8 :name, name
+        name = ensure_utf_8 :name, name
 
         update_options channel_options
         @client        = client
@@ -159,7 +159,7 @@ module Ably
         messages = if name.kind_of?(Enumerable)
           name
         else
-          ensure_utf_8 :name, name, allow_nil: true
+          name = ensure_utf_8 :name, name, allow_nil: true
           ensure_supported_payload data
           [{ name: name, data: data }.merge(attributes)]
         end

--- a/lib/ably/realtime/channel.rb
+++ b/lib/ably/realtime/channel.rb
@@ -93,7 +93,7 @@ module Ably
       # @option channel_options [Hash,Ably::Models::CipherParams]   :cipher   A hash of options or a {Ably::Models::CipherParams} to configure the encryption. *:key* is required, all other options are optional.  See {Ably::Util::Crypto#initialize} for a list of +:cipher+ options
       #
       def initialize(client, name, channel_options = {})
-        name = ensure_utf_8 :name, name
+        name = ensure_utf_8(:name, name)
 
         update_options channel_options
         @client        = client
@@ -159,7 +159,7 @@ module Ably
         messages = if name.kind_of?(Enumerable)
           name
         else
-          name = ensure_utf_8 :name, name, allow_nil: true
+          name = ensure_utf_8(:name, name, allow_nil: true)
           ensure_supported_payload data
           [{ name: name, data: data }.merge(attributes)]
         end

--- a/lib/ably/rest/channel.rb
+++ b/lib/ably/rest/channel.rb
@@ -22,7 +22,7 @@ module Ably
       # @option channel_options [Hash,Ably::Models::CipherParams]   :cipher   A hash of options or a {Ably::Models::CipherParams} to configure the encryption. *:key* is required, all other options are optional.  See {Ably::Util::Crypto#initialize} for a list of +:cipher+ options
       #
       def initialize(client, name, channel_options = {})
-        name = ensure_utf_8 :name, name
+        name = ensure_utf_8(:name, name)
 
         update_options channel_options
         @client  = client
@@ -58,7 +58,7 @@ module Ably
         messages = if name.kind_of?(Enumerable)
           name
         else
-          name = ensure_utf_8 :name, name, allow_nil: true
+          name = ensure_utf_8(:name, name, allow_nil: true)
           ensure_supported_payload data
           [{ name: name, data: data }.merge(attributes)]
         end

--- a/lib/ably/rest/channel.rb
+++ b/lib/ably/rest/channel.rb
@@ -22,7 +22,7 @@ module Ably
       # @option channel_options [Hash,Ably::Models::CipherParams]   :cipher   A hash of options or a {Ably::Models::CipherParams} to configure the encryption. *:key* is required, all other options are optional.  See {Ably::Util::Crypto#initialize} for a list of +:cipher+ options
       #
       def initialize(client, name, channel_options = {})
-        ensure_utf_8 :name, name
+        name = ensure_utf_8 :name, name
 
         update_options channel_options
         @client  = client
@@ -58,7 +58,7 @@ module Ably
         messages = if name.kind_of?(Enumerable)
           name
         else
-          ensure_utf_8 :name, name, allow_nil: true
+          name = ensure_utf_8 :name, name, allow_nil: true
           ensure_supported_payload data
           [{ name: name, data: data }.merge(attributes)]
         end

--- a/spec/unit/rest/channel_spec.rb
+++ b/spec/unit/rest/channel_spec.rb
@@ -22,6 +22,19 @@ describe Ably::Rest::Channel do
       end
     end
 
+    context 'as frozen UTF_8 string' do
+      let(:channel_name) { 'unique'.freeze }
+      let(:encoding) { Encoding::UTF_8 }
+
+      it 'is permitted' do
+        expect(subject.name).to eql(channel_name)
+      end
+
+      it 'remains as UTF-8' do
+        expect(subject.name.encoding).to eql(encoding)
+      end
+    end
+
     context 'as SHIFT_JIS string' do
       let(:encoding) { Encoding::SHIFT_JIS }
 
@@ -67,6 +80,15 @@ describe Ably::Rest::Channel do
     let(:encoded_value) { random_str.encode(encoding) }
 
     context 'as UTF_8 string' do
+      let(:encoding) { Encoding::UTF_8 }
+
+      it 'is permitted' do
+        expect(subject.publish(encoded_value, 'data')).to eql(true)
+      end
+    end
+
+    context 'as frozen UTF_8 string' do
+      let(:encoded_value) { 'unique'.freeze }
       let(:encoding) { Encoding::UTF_8 }
 
       it 'is permitted' do


### PR DESCRIPTION
Pretty straight forward fix.  As Ruby moves towards making all string literals frozen by default, more people might hit problems with this as time goes on.

Fixes https://github.com/ably/ably-ruby/issues/132