### PR TITLE
Fix mock for custom logger

### DIFF
--- a/spec/acceptance/rest/client_spec.rb
+++ b/spec/acceptance/rest/client_spec.rb
@@ -970,8 +970,8 @@ describe Ably::Rest::Client do
               end
 
               [:fatal, :error, :warn, :info, :debug].each do |severity|
-                define_method severity do |message, &block|
-                  message_val = [message]
+                define_method severity do |*args, &block|
+                  message_val = [args]
                   message_val << block.call if block
 
                   @messages << [severity, message_val.compact.join(' ')]


### PR DESCRIPTION
Fixes [this kind of failing tests](https://travis-ci.org/ably/ably-ruby-rest/jobs/370630068#L3392), which curiously pass on this repo, but don't on `ably-ruby-rest`