### PR TITLE
Only resume if connection is fresh (RTN15g*)

### DIFF
--- a/lib/ably/realtime/connection.rb
+++ b/lib/ably/realtime/connection.rb
@@ -615,6 +615,8 @@ module Ably
       def connection_state_available?
         return true if connected?
 
+        return false if time_since_connection_confirmed_alive? > connection_state_ttl
+
         connected_last = state_history.reverse.find { |connected| connected.fetch(:state) == :connected }
         if connected_last.nil? || (connected_last.fetch(:transitioned_at) < Time.now - connection_state_ttl)
           false


### PR DESCRIPTION
Previously we would resume a connection even if the last time we had contacted Ably was greater than the max connection state TTL. As a result, we would try and resume a connection that is guaranteed not to be there.

This implements spec at https://github.com/ably/docs/pull/331