### PR TITLE
Add support for WebSocket native heartbeats

### DIFF
--- a/ably.gemspec
+++ b/ably.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   else
     spec.add_runtime_dependency 'json'
   end
-  spec.add_runtime_dependency 'websocket-driver', '~> 0.6'
+  spec.add_runtime_dependency 'websocket-driver', '~> 0.7'
   spec.add_runtime_dependency 'msgpack', '>= 0.6.2'
   spec.add_runtime_dependency 'addressable', '>= 2.0.0'
 

--- a/lib/ably/realtime/connection.rb
+++ b/lib/ably/realtime/connection.rb
@@ -423,9 +423,12 @@ module Ably
                 lib:        client.rest_client.lib_version_id,
               )
 
-              # Use native websocket heartbeats if possible
-              # TODO: Fix once https://github.com/ably/ably-ruby/issues/116 is resolved
-              url_params['heartbeats'] = 'true' # unless defaults.fetch(:websocket_heartbeats_disabled)
+              # Use native websocket heartbeats if possible, but allow Ably protocol heartbeats
+              url_params['heartbeats'] = if defaults.fetch(:websocket_heartbeats_disabled)
+                'true'
+              else
+                'false'
+              end
 
               url_params['clientId'] = client.auth.client_id if client.auth.has_client_id?
 

--- a/spec/acceptance/realtime/connection_spec.rb
+++ b/spec/acceptance/realtime/connection_spec.rb
@@ -980,7 +980,6 @@ describe Ably::Realtime::Connection, :event_machine do
 
       context 'transport-level heartbeats are supported in the websocket transport' do
         it 'provides the heartbeats argument in the websocket connection params (#RTN23b)' do
-          skip 'Native heartbeats not yet supported in the WS driver https://github.com/ably/ably-ruby/issues/116'
           expect(EventMachine).to receive(:connect) do |host, port, transport, object, url|
             uri = URI.parse(url)
             expect(CGI::parse(uri.query)['heartbeats'][0]).to eql('false')
@@ -990,12 +989,10 @@ describe Ably::Realtime::Connection, :event_machine do
         end
 
         it 'receives websocket heartbeat messages (#RTN23b) [slow test as need to wait for heartbeat]', em_timeout: 45 do
-          skip "Heartbeats param is missing from realtime implementation, see https://github.com/ably/realtime/issues/656"
-
           connection.once(:connected) do
             connection.__incoming_protocol_msgbus__.subscribe(:protocol_message) do |protocol_message|
               if protocol_message.action == :heartbeat
-                expect(protocol_message.attributes[:source]).to eql('websocket')
+                expect(protocol_message.attributes[:source]).to eql(:websocket)
                 expect(connection.time_since_connection_confirmed_alive?).to be_within(1).of(0)
                 stop_reactor
               end
@@ -1021,7 +1018,7 @@ describe Ably::Realtime::Connection, :event_machine do
           connection.once(:connected) do
             connection.__incoming_protocol_msgbus__.subscribe(:protocol_message) do |protocol_message|
               if protocol_message.action == :heartbeat
-                expect(protocol_message.attributes[:source]).to_not eql('websocket')
+                expect(protocol_message.attributes[:source]).to_not eql(:websocket)
                 expect(connection.time_since_connection_confirmed_alive?).to be_within(1).of(0)
                 stop_reactor
               end

--- a/spec/acceptance/realtime/connection_spec.rb
+++ b/spec/acceptance/realtime/connection_spec.rb
@@ -1018,6 +1018,7 @@ describe Ably::Realtime::Connection, :event_machine do
           connection.once(:connected) do
             connection.__incoming_protocol_msgbus__.subscribe(:protocol_message) do |protocol_message|
               if protocol_message.action == :heartbeat
+                next if protocol_message.attributes[:source] == :websocket # ignore the native heartbeats
                 expect(protocol_message.attributes[:source]).to_not eql(:websocket)
                 expect(connection.time_since_connection_confirmed_alive?).to be_within(1).of(0)
                 stop_reactor


### PR DESCRIPTION
Fixes https://github.com/ably/ably-ruby/issues/116

We can now use native heartbeats with the Ably lib thanks to @jcoglan merging in [my ping/pong PR](https://github.com/faye/websocket-driver-ruby/pull/51)