### PR TITLE
Add request id fix for bulk publishes

### DIFF
--- a/lib/ably/auth.rb
+++ b/lib/ably/auth.rb
@@ -633,7 +633,7 @@ module Ably
       method = auth_options[:auth_method] || options[:auth_method] || :get
       params = (auth_options[:auth_params] || options[:auth_method] || {}).merge(token_params)
 
-      response = connection.send(method) do |request|
+      response = connection.public_send(method) do |request|
         request.url uri.path
         request.headers = auth_options[:auth_headers] || {}
         if method.to_s.downcase == 'post'

--- a/lib/ably/modules/encodeable.rb
+++ b/lib/ably/modules/encodeable.rb
@@ -95,7 +95,7 @@ module Ably::Modules
 
         previous_encoding = message_attributes[:encoding]
         encoders.each do |encoder|
-          encoder.send method, message_attributes, channel_options
+          encoder.public_send method, message_attributes, channel_options
         end
       end until previous_encoding == message_attributes[:encoding]
 

--- a/lib/ably/rest/client.rb
+++ b/lib/ably/rest/client.rb
@@ -439,22 +439,14 @@ module Ably
         max_retry_duration = http_defaults.fetch(:max_retry_duration)
         requested_at       = Time.now
         retry_count        = 0
-        request_id         = nil
-        if add_request_ids
-          params = if params.nil?
-            {}
-          else
-            params.dup
-          end
-          request_id = SecureRandom.urlsafe_base64(10)
-          params[:request_id] = request_id
-        end
+        request_id         = SecureRandom.urlsafe_base64(10) if add_request_ids
 
         begin
           use_fallback = can_fallback_to_alternate_ably_host? && retry_count > 0
 
           connection(use_fallback: use_fallback).send(method, path, params) do |request|
             if add_request_ids
+              request.params[:request_id] = request_id
               request.options.context = {} if request.options.context.nil?
               request.options.context[:request_id] = request_id
             end

--- a/spec/acceptance/realtime/auth_spec.rb
+++ b/spec/acceptance/realtime/auth_spec.rb
@@ -1016,31 +1016,7 @@ describe Ably::Realtime::Auth, :event_machine do
 
     context 'deprecated #authorise' do
       let(:client_options)  { default_options.merge(key: api_key, logger: custom_logger_object, use_token_auth: true) }
-      let(:custom_logger) do
-        Class.new do
-          def initialize
-            @messages = []
-          end
-
-          [:fatal, :error, :warn, :info, :debug].each do |severity|
-            define_method severity do |message|
-              @messages << [severity, message]
-            end
-          end
-
-          def logs
-            @messages
-          end
-
-          def level
-            1
-          end
-
-          def level=(new_level)
-          end
-        end
-      end
-      let(:custom_logger_object) { custom_logger.new }
+      let(:custom_logger_object) { TestLogger.new }
 
       it 'logs a deprecation warning (#RSA10l)' do
         client.auth.authorise

--- a/spec/acceptance/realtime/auth_spec.rb
+++ b/spec/acceptance/realtime/auth_spec.rb
@@ -1014,7 +1014,7 @@ describe Ably::Realtime::Auth, :event_machine do
       end
     end
 
-    context 'deprecated #authorise' do
+    context 'deprecated #authorise', :prevent_log_stubbing do
       let(:client_options)  { default_options.merge(key: api_key, logger: custom_logger_object, use_token_auth: true) }
       let(:custom_logger_object) { TestLogger.new }
 

--- a/spec/acceptance/rest/auth_spec.rb
+++ b/spec/acceptance/rest/auth_spec.rb
@@ -1326,34 +1326,7 @@ describe Ably::Auth do
 
     context 'deprecated #authorise' do
       let(:client_options)  { default_options.merge(key: api_key, logger: custom_logger_object, use_token_auth: true) }
-      let(:custom_logger) do
-        Class.new do
-          def initialize
-            @messages = []
-          end
-
-          [:fatal, :error, :warn, :info, :debug].each do |severity|
-            define_method severity do |message, &block|
-              message_val = [message]
-              message_val << block.call if block
-
-              @messages << [severity, message_val.compact.join(' ')]
-            end
-          end
-
-          def logs
-            @messages
-          end
-
-          def level
-            1
-          end
-
-          def level=(new_level)
-          end
-        end
-      end
-      let(:custom_logger_object) { custom_logger.new }
+      let(:custom_logger_object) { TestLogger.new }
 
       it 'logs a deprecation warning (#RSA10l)' do
         client.auth.authorise

--- a/spec/acceptance/rest/auth_spec.rb
+++ b/spec/acceptance/rest/auth_spec.rb
@@ -1324,7 +1324,7 @@ describe Ably::Auth do
       end
     end
 
-    context 'deprecated #authorise' do
+    context 'deprecated #authorise', :prevent_log_stubbing do
       let(:client_options)  { default_options.merge(key: api_key, logger: custom_logger_object, use_token_auth: true) }
       let(:custom_logger_object) { TestLogger.new }
 

--- a/spec/acceptance/rest/client_spec.rb
+++ b/spec/acceptance/rest/client_spec.rb
@@ -1018,34 +1018,7 @@ describe Ably::Rest::Client do
     context 'request_id generation' do
       context 'Timeout error' do
         context 'with option add_request_ids: true', :webmock do
-          let(:custom_logger) do
-            Class.new do
-              def initialize
-                @messages = []
-              end
-
-              [:fatal, :error, :warn, :info, :debug].each do |severity|
-                define_method severity do |message, &block|
-                  message_val = [message]
-                  message_val << block.call if block
-
-                  @messages << [severity, message_val.compact.join(' ')]
-                end
-              end
-
-              def logs
-                @messages
-              end
-
-              def level
-                1
-              end
-
-              def level=(new_level)
-              end
-            end
-          end
-          let(:custom_logger_object) { custom_logger.new }
+          let(:custom_logger_object) { TestLogger.new }
           let(:client_options) { default_options.merge(key: api_key, logger: custom_logger_object, add_request_ids: true) }
 
           before do
@@ -1163,6 +1136,10 @@ describe Ably::Rest::Client do
           end
         end
       end
+    end
+
+    context 'failed request logging' do
+      it 'does not log success'
     end
   end
 end

--- a/spec/acceptance/rest/client_spec.rb
+++ b/spec/acceptance/rest/client_spec.rb
@@ -1017,7 +1017,7 @@ describe Ably::Rest::Client do
 
     context 'request_id generation' do
       context 'Timeout error' do
-        context 'with option add_request_ids: true', :webmock do
+        context 'with option add_request_ids: true', :webmock, :prevent_log_stubbing do
           let(:custom_logger_object) { TestLogger.new }
           let(:client_options) { default_options.merge(key: api_key, logger: custom_logger_object, add_request_ids: true) }
 
@@ -1138,7 +1138,7 @@ describe Ably::Rest::Client do
       end
     end
 
-    context 'failed request logging' do
+    context 'failed request logging', :prevent_log_stubbing do
       let(:custom_logger) { TestLogger.new }
       let(:client_options) { default_options.merge(key: api_key, logger: custom_logger) }
 

--- a/spec/acceptance/rest/client_spec.rb
+++ b/spec/acceptance/rest/client_spec.rb
@@ -1174,7 +1174,7 @@ describe Ably::Rest::Client do
 
         it 'is present when all requests fail' do
           expect { client.time }.to raise_error(Ably::Exceptions::ConnectionError)
-          expect(custom_logger.logs(min_severity: :warn).select { |severity, msg| msg.match(/Retry/) }.length).to eql(2)
+          expect(custom_logger.logs(min_severity: :warn).select { |severity, msg| msg.match(/Retry/) }.length).to be >= 2
           expect(custom_logger.logs(min_severity: :error).select { |severity, msg| msg.match(/FAILED/) }.length).to eql(1)
         end
       end

--- a/spec/acceptance/rest/client_spec.rb
+++ b/spec/acceptance/rest/client_spec.rb
@@ -1056,7 +1056,9 @@ describe Ably::Rest::Client do
             end
           end
           it 'has an error with the same request_id of the request' do
-            expect{ client.time }.to raise_error(Ably::Exceptions::ConnectionTimeout, /#{@request_id}/)
+            expect { client.time }.to raise_error(Ably::Exceptions::ConnectionTimeout, /#{@request_id}/)
+            expect(@request_id).to be_a(String)
+            expect(@request_id).to_not be_empty
             expect(custom_logger_object.logs.find { |severity, message| message.match(/#{@request_id}/i)} ).to_not be_nil
           end
         end
@@ -1124,6 +1126,8 @@ describe Ably::Rest::Client do
           end
           it 'request_id is the same across retries' do
             expect{ client.time }.to raise_error(Ably::Exceptions::ConnectionTimeout, /#{@request_id}/)
+            expect(@request_id).to be_a(String)
+            expect(@request_id).to_not be_empty
             expect(requests.uniq.count).to eql(1)
             expect(requests.uniq.first).to eql(@request_id)
           end

--- a/spec/shared/client_initializer_behaviour.rb
+++ b/spec/shared/client_initializer_behaviour.rb
@@ -261,15 +261,7 @@ shared_examples 'a client initializer' do
       end
 
       context 'with custom logger and log_level' do
-        let(:custom_logger) do
-          Class.new do
-            extend Forwardable
-            def initialize
-              @logger = Logger.new(STDOUT)
-            end
-            def_delegators :@logger, :fatal, :error, :warn, :info, :debug, :level, :level=
-          end
-        end
+        let(:custom_logger) { TestLogger }
         let(:client_options) { default_options.merge(logger: custom_logger.new, log_level: Logger::DEBUG, auto_connect: false) }
 
         it 'uses the custom logger' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@ require 'support/event_emitter_helper'
 require 'support/private_api_formatter'
 require 'support/protocol_helper'
 require 'support/random_helper'
+require 'support/test_logger_helper'
 
 require 'rspec_config'
 

--- a/spec/support/test_logger_helper.rb
+++ b/spec/support/test_logger_helper.rb
@@ -1,14 +1,21 @@
 # Class with standard Ruby Logger interface
 #   but it keeps a record of the lof entries for later inspection
+#
+# Recommendation: Use :prevent_log_stubbing attibute on tests that use this logger
+#
 class TestLogger
   def initialize
     @messages = []
   end
 
   SEVERITIES = [:fatal, :error, :warn, :info, :debug]
-  SEVERITIES.each do |severity|
-    define_method severity do |message|
-      @messages << [severity, message]
+  SEVERITIES.each do |severity_sym|
+    define_method(severity_sym) do |*args, &block|
+      if block
+        @messages << [severity_sym, block.call]
+      else
+        @messages << [severity_sym, args.join(', ')]
+      end
     end
   end
 

--- a/spec/support/test_logger_helper.rb
+++ b/spec/support/test_logger_helper.rb
@@ -12,7 +12,8 @@ class TestLogger
     end
   end
 
-  def logs(min_severity: nil)
+  def logs(options = {})
+    min_severity = options[:min_severity]
     if min_severity
       severity_level = SEVERITIES.index(min_severity)
       raise "Unknown severity: #{min_severity}" if severity_level.nil?

--- a/spec/support/test_logger_helper.rb
+++ b/spec/support/test_logger_helper.rb
@@ -5,14 +5,24 @@ class TestLogger
     @messages = []
   end
 
-  [:fatal, :error, :warn, :info, :debug].each do |severity|
+  SEVERITIES = [:fatal, :error, :warn, :info, :debug]
+  SEVERITIES.each do |severity|
     define_method severity do |message|
       @messages << [severity, message]
     end
   end
 
-  def logs
-    @messages
+  def logs(min_severity: nil)
+    if min_severity
+      severity_level = SEVERITIES.index(min_severity)
+      raise "Unknown severity: #{min_severity}" if severity_level.nil?
+
+      @messages.select do |severity, message|
+        SEVERITIES.index(severity) <= severity_level
+      end
+    else
+      @messages
+    end
   end
 
   def level

--- a/spec/support/test_logger_helper.rb
+++ b/spec/support/test_logger_helper.rb
@@ -1,0 +1,24 @@
+# Class with standard Ruby Logger interface
+#   but it keeps a record of the lof entries for later inspection
+class TestLogger
+  def initialize
+    @messages = []
+  end
+
+  [:fatal, :error, :warn, :info, :debug].each do |severity|
+    define_method severity do |message|
+      @messages << [severity, message]
+    end
+  end
+
+  def logs
+    @messages
+  end
+
+  def level
+    1
+  end
+
+  def level=(new_level)
+  end
+end

--- a/spec/unit/logger_spec.rb
+++ b/spec/unit/logger_spec.rb
@@ -121,15 +121,7 @@ describe Ably::Logger do
     end
 
     context 'with a valid interface' do
-      let(:custom_logger) do
-        Class.new do
-          extend Forwardable
-          def initialize
-            @logger = Logger.new(STDOUT)
-          end
-          def_delegators :@logger, :fatal, :error, :warn, :info, :debug, :level, :level=
-        end
-      end
+      let(:custom_logger) { TestLogger }
       let(:custom_logger_object) { custom_logger.new }
 
       subject { Ably::Logger.new(rest_client, Logger::INFO, custom_logger_object) }


### PR DESCRIPTION
Unfortunately @funkyboy's implementation did not have test coverage with the new request ID for publish operations, and such, his work introduced a regression.

This PR fixes that, but also:

* Improves those tests marginally
* Fixes a few incorrect calls to potentially private method
* Adds a shared logger for inspecting log output
* [Always logs the outcomes of retry requests](https://github.com/ably/docs/issues/359). I believe this will significantly help people when debugging requests that are retried as the logs will make more sense.