### PR TITLE
Idempotent publishing

### DIFF
--- a/lib/ably/rest/channel.rb
+++ b/lib/ably/rest/channel.rb
@@ -22,6 +22,8 @@ module Ably
       # @api private
       attr_reader :push
 
+      IDEMPOTENT_LIBRARY_GENERATED_ID_LENGTH = 9 # See spec RSL1k1
+
       # Initialize a new Channel object
       #
       # @param client [Ably::Rest::Client]
@@ -93,7 +95,7 @@ module Ably
             # We cannot mutate for idempotent publishing if one or more messages already has an ID
             if payload.all? { |msg| !msg['id'] }
               # Mutate the JSON to support idempotent publishing where a Message.id does not exist
-              idempotent_publish_id = SecureRandom.base64(16)
+              idempotent_publish_id = SecureRandom.base64(IDEMPOTENT_LIBRARY_GENERATED_ID_LENGTH)
               payload.each_with_index do |msg, idx|
                 msg['id'] = "#{idempotent_publish_id}:#{idx}"
               end

--- a/lib/ably/rest/channel.rb
+++ b/lib/ably/rest/channel.rb
@@ -42,7 +42,7 @@ module Ably
       #
       # @param name [String, Array<Ably::Models::Message|Hash>, nil]   The event name of the message to publish, or an Array of [Ably::Model::Message] objects or [Hash] objects with +:name+ and +:data+ pairs
       # @param data [String, ByteArray, nil]   The message payload unless an Array of [Ably::Model::Message] objects passed in the first argument
-      # @param attributes [Hash, nil]   Optional additional message attributes such as :client_id or :connection_id, applied when name attribute is nil or a string
+      # @param attributes [Hash, nil]   Optional additional message attributes such as :extras, :id, :client_id or :connection_id, applied when name attribute is nil or a string
       # @return [Boolean]  true if the message was published, otherwise false
       #
       # @example
@@ -67,6 +67,10 @@ module Ably
         messages = if name.kind_of?(Enumerable)
           name
         else
+          if name.kind_of?(Ably::Models::Message)
+            raise ArgumentError, "name argument does not support single Message objects, only arrays of Message objects"
+          end
+
           name = ensure_utf_8(:name, name, allow_nil: true)
           ensure_supported_payload data
           [{ name: name, data: data }.merge(attributes)]

--- a/lib/ably/rest/channel.rb
+++ b/lib/ably/rest/channel.rb
@@ -87,7 +87,12 @@ module Ably
             unless client.auth.can_assume_client_id?(msg.client_id)
               raise Ably::Exceptions::IncompatibleClientId.new("Cannot publish with client_id '#{msg.client_id}' as it is incompatible with the current configured client_id '#{client.client_id}'")
             end
-          end.as_json
+          end.as_json.tap do |msg|
+            # Mutate the JSON to support idempotent publishing where a Message.id does not exist
+            unless msg['id']
+              msg['id'] = SecureRandom.hex(16).force_encoding('UTF-8')
+            end
+          end
         end
 
         response = client.post("#{base_path}/publish", payload.length == 1 ? payload.first : payload)

--- a/lib/ably/rest/client.rb
+++ b/lib/ably/rest/client.rb
@@ -85,7 +85,7 @@ module Ably
       # if empty or nil then fallback host functionality is disabled
       attr_reader :fallback_hosts
 
-      # Whethere the {Client} has to add a random identifier to the path of a request
+      # Whether the {Client} has to add a random identifier to the path of a request
       # @return [Boolean]
       attr_reader :add_request_ids
 
@@ -93,6 +93,14 @@ module Ably
       # @return [Boolean]
       # @api private
       attr_reader :log_retries_as_info
+
+      # True when idempotent publishing is enabled for all messages published via REST.
+      # When this feature is enabled, the client library will add a unique ID to every published message (without an ID)
+      # ensuring any failed published attempts (due to failures such as HTTP requests failing mid-flight) that are
+      # automatically retried will not result in duplicate messages being published to the Ably platform.
+      # Note: This is a beta unsupported feature!
+      # @return [Boolean]
+      attr_reader :idempotent_rest_publishing
 
       # Creates a {Ably::Rest::Client Rest Client} and configures the {Ably::Auth} object for the connection.
       #
@@ -127,6 +135,7 @@ module Ably
       # @option options [Integer]                 :fallback_retry_timeout     (600 seconds) amount of time in seconds a REST client will continue to use a working fallback host when the primary fallback host has previously failed
       #
       # @option options [Boolean]                 :add_request_ids             (false) When true, adds a unique request_id to each request sent to Ably servers. This is handy when reporting issues, because you can refer to a specific request.
+      # @option options [Boolean]                 :idempotent_rest_publishing  (false) When true, idempotent publishing is enabled for all messages published via REST
       #
       # @return [Ably::Rest::Client]
       #
@@ -162,6 +171,7 @@ module Ably
         @custom_tls_port     = options.delete(:tls_port)
         @add_request_ids     = options.delete(:add_request_ids)
         @log_retries_as_info = options.delete(:log_retries_as_info)
+        @idempotent_rest_publishing = options.delete(:idempotent_rest_publishing)
 
         if options[:fallback_hosts_use_default] && options[:fallback_jhosts]
           raise ArgumentError, "fallback_hosts_use_default cannot be set to trye when fallback_jhosts is also provided"

--- a/lib/ably/rest/client.rb
+++ b/lib/ably/rest/client.rb
@@ -135,7 +135,7 @@ module Ably
       # @option options [Integer]                 :fallback_retry_timeout     (600 seconds) amount of time in seconds a REST client will continue to use a working fallback host when the primary fallback host has previously failed
       #
       # @option options [Boolean]                 :add_request_ids             (false) When true, adds a unique request_id to each request sent to Ably servers. This is handy when reporting issues, because you can refer to a specific request.
-      # @option options [Boolean]                 :idempotent_rest_publishing  (false) When true, idempotent publishing is enabled for all messages published via REST
+      # @option options [Boolean]                 :idempotent_rest_publishing  (false if ver < 1.2) When true, idempotent publishing is enabled for all messages published via REST
       #
       # @return [Ably::Rest::Client]
       #
@@ -171,7 +171,8 @@ module Ably
         @custom_tls_port     = options.delete(:tls_port)
         @add_request_ids     = options.delete(:add_request_ids)
         @log_retries_as_info = options.delete(:log_retries_as_info)
-        @idempotent_rest_publishing = options.delete(:idempotent_rest_publishing)
+        @idempotent_rest_publishing = options.delete(:idempotent_rest_publishing) || Ably.major_minor_version_numeric > 1.1
+
 
         if options[:fallback_hosts_use_default] && options[:fallback_jhosts]
           raise ArgumentError, "fallback_hosts_use_default cannot be set to trye when fallback_jhosts is also provided"

--- a/lib/ably/version.rb
+++ b/lib/ably/version.rb
@@ -13,4 +13,9 @@ module Ably
   def self.lib_variant
     @lib_variant
   end
+
+  # @api private
+  def self.major_minor_version_numeric
+    VERSION.gsub(/\.\d+$/, '').to_f
+  end
 end

--- a/spec/acceptance/rest/message_spec.rb
+++ b/spec/acceptance/rest/message_spec.rb
@@ -136,6 +136,13 @@ describe Ably::Rest::Channel, 'messages' do
           channel.publish 'event', data, id: id
           expect(channel.history.items[0].id).to eql(id)
         end
+
+        specify 'for multiple messages in one publish operation' do
+          message_arr = 3.times.map { Ably::Models::Message.new(id: id, data: data) }
+          expect { channel.publish message_arr }.to raise_error do |error|
+            expect(error.code).to eql(40007)
+          end
+        end
       end
 
       context 'when idempotent publishing is enabled in the client library ClientOptions' do
@@ -186,6 +193,12 @@ describe Ably::Rest::Channel, 'messages' do
             expect(channel.history.items[0].id).to eql(id)
             expect(@failed_http_posts).to eql(2)
           end
+        end
+
+        specify 'for multiple messages in one publish operation' do
+          message_arr = 3.times.map { Ably::Models::Message.new(data: data) }
+          3.times { channel.publish message_arr }
+          expect(channel.history.items.length).to eql(1)
         end
 
         specify 'the ID is populated with the random ID from this lib' do

--- a/spec/acceptance/rest/message_spec.rb
+++ b/spec/acceptance/rest/message_spec.rb
@@ -154,9 +154,15 @@ describe Ably::Rest::Channel, 'messages' do
         end
       end
 
-      specify 'idempotent publishing is disabled by default (#TO3n)' do
+      specify 'idempotent publishing is disabled by default with 1.1 (#TO3n)' do
         client = Ably::Rest::Client.new(key: api_key, protocol: protocol)
         expect(client.idempotent_rest_publishing).to be_falsey
+      end
+
+      specify 'idempotent publishing is enabled by default with 1.2 (#TO3n)' do
+        stub_const 'Ably::VERSION', '1.2.0'
+        client = Ably::Rest::Client.new(key: api_key, protocol: protocol)
+        expect(client.idempotent_rest_publishing).to be_truthy
       end
 
       context 'when idempotent publishing is enabled in the client library ClientOptions (#TO3n)' do

--- a/spec/acceptance/rest/message_spec.rb
+++ b/spec/acceptance/rest/message_spec.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require 'spec_helper'
+require 'base64'
 require 'securerandom'
 
 describe Ably::Rest::Channel, 'messages' do
@@ -91,12 +92,12 @@ describe Ably::Rest::Channel, 'messages' do
       end
     end
 
-    context 'idempotency' do
+    context 'idempotency (#RSL1k)' do
       let(:id) { random_str }
       let(:name) { 'event' }
       let(:data) { random_str }
 
-      context 'when ID is not included' do
+      context 'when ID is not included (#RSL1k2)' do
         context 'with Message object' do
           let(:message) { Ably::Models::Message.new(data: data) }
 
@@ -114,11 +115,11 @@ describe Ably::Rest::Channel, 'messages' do
         end
       end
 
-      context 'when ID is included' do
+      context 'when ID is included (#RSL1k2, #RSL1k5)' do
         context 'with Message object' do
           let(:message) { Ably::Models::Message.new(id: id, data: data) }
 
-          it 'three REST publishes result in only one message being published' do
+          specify 'three REST publishes result in only one message being published' do
             3.times { channel.publish [message] }
             expect(channel.history.items.length).to eql(1)
             expect(channel.history.items[0].id).to eql(id)
@@ -137,73 +138,102 @@ describe Ably::Rest::Channel, 'messages' do
           expect(channel.history.items[0].id).to eql(id)
         end
 
-        specify 'for multiple messages in one publish operation' do
+        specify 'for multiple messages in one publish operation (#RSL1k3)' do
           message_arr = 3.times.map { Ably::Models::Message.new(id: id, data: data) }
           expect { channel.publish message_arr }.to raise_error do |error|
-            expect(error.code).to eql(40007)
+            expect(error.code).to eql(40031) # Invalid publish request (invalid client-specified id), see https://github.com/ably/ably-common/pull/30
           end
+        end
+
+        specify 'for multiple messages in one publish operation with IDs following the required format described in RSL1k1 (#RSL1k3)' do
+          message_arr = 3.times.map { |index| Ably::Models::Message.new(id: "#{id}:#{index}", data: data) }
+          channel.publish message_arr
+          expect(channel.history.items[0].id).to eql("{id}:0")
+          expect(channel.history.items[2].id).to eql("{id}:2")
+          expect(channel.history.items.length).to eql(3)
         end
       end
 
-      context 'when idempotent publishing is enabled in the client library ClientOptions' do
+      specify 'idempotent publishing is disabled by default (#TO3n)' do
+        client = Ably::Rest::Client.new(key: api_key, protocol: protocol)
+        expect(client.idempotent_rest_publishing).to be_falsey
+      end
+
+      context 'when idempotent publishing is enabled in the client library ClientOptions (#TO3n)' do
         let(:client_options) { default_client_options.merge(idempotent_rest_publishing: true, log_level: :error) }
 
-        def mock_for_two_publish_failures
-          @failed_http_posts = 0
-          allow(client).to receive(:can_fallback_to_alternate_ably_host?).and_return(true)
-          allow_any_instance_of(Faraday::Connection).to receive(:post) do |*args|
-            @failed_http_posts += 1
-            if @failed_http_posts == 2
-              # Ensure the 3rd requests operates as normal
-              allow_any_instance_of(Faraday::Connection).to receive(:post).and_call_original
+        context 'when there is a network failure triggering an automatic retry (#RSL1k4)' do
+          def mock_for_two_publish_failures
+            @failed_http_posts = 0
+            allow(client).to receive(:can_fallback_to_alternate_ably_host?).and_return(true)
+            allow_any_instance_of(Faraday::Connection).to receive(:post) do |*args|
+              @failed_http_posts += 1
+              if @failed_http_posts == 2
+                # Ensure the 3rd requests operates as normal
+                allow_any_instance_of(Faraday::Connection).to receive(:post).and_call_original
+              end
+              raise Faraday::ClientError.new('Fake client error')
             end
-            raise Faraday::ClientError.new('Fake client error')
+          end
+
+          context 'with Message object' do
+            let(:message) { Ably::Models::Message.new(data: data) }
+            before { mock_for_two_publish_failures }
+
+            specify 'two REST publish retries result in only one message being published' do
+              channel.publish [message]
+              expect(channel.history.items.length).to eql(1)
+              expect(@failed_http_posts).to eql(2)
+            end
+          end
+
+          context 'with #publish arguments only' do
+            before { mock_for_two_publish_failures }
+
+            specify 'two REST publish retries result in only one message being published' do
+              channel.publish 'event', data
+              expect(channel.history.items.length).to eql(1)
+              expect(@failed_http_posts).to eql(2)
+            end
+          end
+
+          context 'with explicitly provided message ID' do
+            let(:id) { random_str }
+
+            before { mock_for_two_publish_failures }
+
+            specify 'two REST publish retries result in only one message being published' do
+              channel.publish 'event', data, id: id
+              expect(channel.history.items.length).to eql(1)
+              expect(channel.history.items[0].id).to eql(id)
+              expect(@failed_http_posts).to eql(2)
+            end
+          end
+
+          specify 'for multiple messages in one publish operation' do
+            message_arr = 3.times.map { Ably::Models::Message.new(data: data) }
+            3.times { channel.publish message_arr }
+            expect(channel.history.items.length).to eql(message_arr.length)
           end
         end
 
-        context 'with Message object' do
-          let(:message) { Ably::Models::Message.new(data: data) }
-          before { mock_for_two_publish_failures }
-
-          it 'three REST publishes result in only one message being published' do
-            channel.publish [message]
-            expect(channel.history.items.length).to eql(1)
-            expect(@failed_http_posts).to eql(2)
-          end
-        end
-
-        context 'with #publish arguments only' do
-          before { mock_for_two_publish_failures }
-
-          it 'three REST publishes result in only one message being published' do
-            channel.publish 'event', data
-            expect(channel.history.items.length).to eql(1)
-            expect(@failed_http_posts).to eql(2)
-          end
-        end
-
-        context 'with explicitily provided message ID' do
-          let(:id) { random_str }
-
-          before { mock_for_two_publish_failures }
-
-          it 'three REST publishes result in only one message being published with the explicitly provided ID' do
-            channel.publish 'event', data, id: id
-            expect(channel.history.items.length).to eql(1)
-            expect(channel.history.items[0].id).to eql(id)
-            expect(@failed_http_posts).to eql(2)
-          end
-        end
-
-        specify 'for multiple messages in one publish operation' do
-          message_arr = 3.times.map { Ably::Models::Message.new(data: data) }
-          3.times { channel.publish message_arr }
-          expect(channel.history.items.length).to eql(1)
-        end
-
-        specify 'the ID is populated with the random ID from this lib' do
+        specify 'the ID is populated with a random ID and serial 0 from this lib (#RSL1k1)' do
           channel.publish 'event'
-          expect(channel.history.items[0].id).to match(/^[a-f0-9]{32}$/)
+          expect(channel.history.items[0].id).to match(/^[A-Za-z0-9\+\/]+:0$/)
+          base_64_id = channel.history.items[0].id.split(':')[0]
+          expect(Base64.decode64(base_64_id).length).to eql(9)
+        end
+
+        context 'when publishing a batch of messages' do
+          specify 'the ID is populated with a single random ID and sequence of serials from this lib (#RSL1k1)' do
+            message = { name: 'event' }
+            channel.publish [message, message, message]
+            expect(channel.history.items[0].length).to eql(3)
+            expect(channel.history.items[0].id).to match(/^[A-Za-z0-9\+\/]+:0$/)
+            expect(channel.history.items[2].id).to match(/^[A-Za-z0-9\+\/]+:2$/)
+            base_64_id = channel.history.items[0].id.split(':')[0]
+            expect(Base64.decode64(base_64_id).length).to eql(9)
+          end
         end
       end
     end

--- a/spec/unit/models/message_spec.rb
+++ b/spec/unit/models/message_spec.rb
@@ -16,6 +16,20 @@ describe Ably::Models::Message do
     let(:model_args) { [protocol_message: protocol_message] }
   end
 
+  # TODO: Assign spec item for serialization of ID
+  context '#id' do
+    let(:id) { random_str }
+    let(:model) { subject.new(id: id) }
+
+    it 'exposes the #id attribute' do
+      expect(model.id).to eql(id)
+    end
+
+    specify '#as_json exposes the #id attribute' do
+      expect(model.as_json['id']).to eql(id)
+    end
+  end
+
   context '#timestamp' do
     let(:model) { subject.new({}, protocol_message: protocol_message) }
 

--- a/spec/unit/models/message_spec.rb
+++ b/spec/unit/models/message_spec.rb
@@ -12,12 +12,13 @@ describe Ably::Models::Message do
   let(:protocol_message_timestamp) { as_since_epoch(Time.now) }
   let(:protocol_message) { Ably::Models::ProtocolMessage.new(action: 1, timestamp: protocol_message_timestamp) }
 
-  it_behaves_like 'a model', with_simple_attributes: %w(id name client_id data encoding) do
-    let(:model_args) { [protocol_message: protocol_message] }
+  context 'serialization of the Message object (#RSL1j)' do
+    it_behaves_like 'a model', with_simple_attributes: %w(id name client_id data encoding) do
+      let(:model_args) { [protocol_message: protocol_message] }
+    end
   end
 
-  # TODO: Assign spec item for serialization of ID
-  context '#id' do
+  context '#id (#RSL1j)' do
     let(:id) { random_str }
     let(:model) { subject.new(id: id) }
 


### PR DESCRIPTION
Unless I am mistaken, we don't have a spec for idempotent publishing, so I have created this PR to help us define what functionality we may to include in the spec for this. See issue at https://github.com/ably/docs/issues/469 relating to idempotent publishing in the spec.

Note:

* I additionally added a new ClientOptions as a beta feature that enables idempotent publishing to all publishes.  It's disabled by default. I propose this is included in 1.1.
* When we release 1.2, we may want to consider enabling this feature by default.

