### PR TITLE
Transient publishing for #164

### DIFF
--- a/lib/ably/models/protocol_message.rb
+++ b/lib/ably/models/protocol_message.rb
@@ -198,12 +198,42 @@ module Ably::Models
 
     # @api private
     def has_backlog_flag?
-      flags & 2 == 2
+      flags & 2 == 2 # 2^1
     end
 
     # @api private
     def has_channel_resumed_flag?
-      flags & 4 == 4
+      flags & 4 == 4 # 2^2
+    end
+
+    # @api private
+    def has_local_presence_flag?
+      flags & 8 == 8 # 2^3
+    end
+
+    # @api private
+    def has_transient_flag?
+      flags & 16 == 16 # 2^4
+    end
+
+    # @api private
+    def has_attach_presence_flag?
+      flags & 65536 == 65536 # 2^16
+    end
+
+    # @api private
+    def has_attach_publish_flag?
+      flags & 131072 == 131072 # 2^17
+    end
+
+    # @api private
+    def has_attach_subscribe_flag?
+      flags & 262144 == 262144 # 2^18
+    end
+
+    # @api private
+    def has_attach_presence_subscribe_flag?
+      flags & 524288 == 524288 # 2^19
     end
 
     def connection_details

--- a/lib/ably/realtime/channel.rb
+++ b/lib/ably/realtime/channel.rb
@@ -161,7 +161,7 @@ module Ably
         end
 
         if !connection.can_publish_messages?
-          error = Ably::Exceptions::MessageQueueingDisabled.new("Message cannot be published. Client is not allowed to queue of messages when connection is in state #{connection.state}")
+          error = Ably::Exceptions::MessageQueueingDisabled.new("Message cannot be published. Client is not allowed to queue messages when connection is in state #{connection.state}")
           return Ably::Util::SafeDeferrable.new_and_fail_immediately(logger, error)
         end
 

--- a/lib/ably/realtime/channel/channel_manager.rb
+++ b/lib/ably/realtime/channel/channel_manager.rb
@@ -111,16 +111,12 @@ module Ably::Realtime
         end
       end
 
-      # When a channel becomes detached, suspended or failed,
+      # When a channel becomes suspended or failed,
       # all queued messages should be failed immediately as we don't queue in
       # any of those states
       def fail_queued_messages(error)
         error = Ably::Exceptions::MessageDeliveryFailed.new("Queued messages on channel '#{channel.name}' in state '#{channel.state}' will never be delivered") unless error
         fail_messages_in_queue connection.__outgoing_message_queue__, error
-        channel.__queue__.each do |message|
-          nack_message message, error
-        end
-        channel.__queue__.clear
       end
 
       def fail_messages_in_queue(queue, error)

--- a/lib/ably/realtime/channel/channel_state_machine.rb
+++ b/lib/ably/realtime/channel/channel_state_machine.rb
@@ -47,7 +47,7 @@ module Ably::Realtime
 
       after_transition(to: [:detached, :failed, :suspended]) do |channel, current_transition|
         err = error_from_state_change(current_transition)
-        channel.manager.fail_queued_messages err
+        channel.manager.fail_queued_messages(err) if channel.failed? or channel.suspended? #RTL11
         channel.manager.log_channel_error err if err
       end
 

--- a/lib/ably/realtime/channel/publisher.rb
+++ b/lib/ably/realtime/channel/publisher.rb
@@ -1,0 +1,74 @@
+module Ably::Realtime
+  class Channel
+    # Publisher module adds publishing capabilities to the current object
+    module Publisher
+      private
+
+      # Prepare and queue messages on the connection queue immediately
+      # @return [Ably::Util::SafeDeferrable]
+      def enqueue_messages_on_connection(client, raw_messages, channel_name, channel_options = {})
+        messages = Array(raw_messages).map do |raw_msg|
+          create_message(client, raw_msg, channel_options).tap do |message|
+            next if message.client_id.nil?
+            if message.client_id == '*'
+              raise Ably::Exceptions::IncompatibleClientId.new('Wildcard client_id is reserved and cannot be used when publishing messages')
+            end
+            if message.client_id && !message.client_id.kind_of?(String)
+              raise Ably::Exceptions::IncompatibleClientId.new('client_id must be a String when publishing messages')
+            end
+            unless client.auth.can_assume_client_id?(message.client_id)
+              raise Ably::Exceptions::IncompatibleClientId.new("Cannot publish with client_id '#{message.client_id}' as it is incompatible with the current configured client_id '#{client.client_id}'")
+            end
+          end
+        end
+
+        connection.send_protocol_message(
+          action:   Ably::Models::ProtocolMessage::ACTION.Message.to_i,
+          channel:  channel_name,
+          messages: messages
+        )
+
+        if messages.count == 1
+          # A message is a Deferrable so, if publishing only one message, simply return that Deferrable
+          messages.first
+        else
+          deferrable_for_multiple_messages(messages)
+        end
+      end
+
+      # A deferrable object that calls the success callback once all messages are delivered
+      # If any message fails, the errback is called immediately
+      # Only one callback or errback is ever called i.e. if a group of messages all fail, only once
+      # errback will be invoked
+      def deferrable_for_multiple_messages(messages)
+        expected_deliveries = messages.count
+        actual_deliveries = 0
+        failed = false
+
+        Ably::Util::SafeDeferrable.new(logger).tap do |deferrable|
+          messages.each do |message|
+            message.callback do
+              next if failed
+              actual_deliveries += 1
+              deferrable.succeed messages if actual_deliveries == expected_deliveries
+            end
+            message.errback do |error|
+              next if failed
+              failed = true
+              deferrable.fail error, message
+            end
+          end
+        end
+      end
+
+      def create_message(client, message, channel_options)
+        Ably::Models::Message(message.dup).tap do |msg|
+          msg.encode(client.encoders, channel_options) do |encode_error, error_message|
+            client.logger.error error_message
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/lib/ably/realtime/client.rb
+++ b/lib/ably/realtime/client.rb
@@ -229,7 +229,7 @@ module Ably
       #
       def publish(channel_name, name, data = nil, attributes = {}, &success_block)
         if !connection.can_publish_messages?
-          error = Ably::Exceptions::MessageQueueingDisabled.new("Message cannot be published. Client is not allowed to queue of messages when connection is in state #{connection.state}")
+          error = Ably::Exceptions::MessageQueueingDisabled.new("Message cannot be published. Client is not allowed to queue messages when connection is in state #{connection.state}")
           return Ably::Util::SafeDeferrable.new_and_fail_immediately(logger, error)
         end
 

--- a/lib/ably/realtime/client.rb
+++ b/lib/ably/realtime/client.rb
@@ -1,4 +1,5 @@
 require 'uri'
+require 'ably/realtime/channel/publisher'
 
 module Ably
   module Realtime
@@ -21,6 +22,9 @@ module Ably
     #
     class Client
       include Ably::Modules::AsyncWrapper
+      include Ably::Realtime::Channel::Publisher
+      include Ably::Modules::Conversions
+
       extend Forwardable
 
       DOMAIN = 'realtime.ably.io'
@@ -176,6 +180,74 @@ module Ably
       def request(method, path, params = {}, body = nil, headers = {}, &callback)
         async_wrap(callback) do
           rest_client.request(method, path, params, body, headers, async_blocking_operations: true)
+        end
+      end
+
+      # Publish one or more messages to the specified channel.
+      #
+      # This method allows messages to be efficiently published to Ably without instancing a {Ably::Realtime::Channel} object.
+      # If you want to publish a high rate of messages to Ably without instancing channels or using the REST API, then this method
+      # is recommended. However, channel options such as encryption are not supported with this method.  If you need to specify channel options
+      # we recommend you use the {Ably::Realtime::Channel} +publish+ method without attaching to each channel, unless you also want to subscribe
+      # to published messages on that channel.
+      #
+      # Note: This feature is still in beta. As such, we cannot guarantee the API will not change in future.
+      #
+      # @param channel [String]   The channel name you want to publish the message(s) to
+      # @param name [String, Array<Ably::Models::Message|Hash>, nil]   The event name of the message to publish, or an Array of [Ably::Model::Message] objects or [Hash] objects with +:name+ and +:data+ pairs
+      # @param data [String, ByteArray, nil]   The message payload unless an Array of [Ably::Model::Message] objects passed in the first argument
+      # @param attributes [Hash, nil]   Optional additional message attributes such as :client_id or :connection_id, applied when name attribute is nil or a string
+      #
+      # @yield [Ably::Models::Message,Array<Ably::Models::Message>] On success, will call the block with the {Ably::Models::Message} if a single message is published, or an Array of {Ably::Models::Message} when multiple messages are published
+      # @return [Ably::Util::SafeDeferrable] Deferrable that supports both success (callback) and failure (errback) callbacks
+      #
+      # @example
+      #   # Publish a single message
+      #   client.publish 'activityChannel', click', { x: 1, y: 2 }
+      #
+      #   # Publish an array of message Hashes
+      #   messages = [
+      #     { name: 'click', { x: 1, y: 2 } },
+      #     { name: 'click', { x: 2, y: 3 } }
+      #   ]
+      #   client.publish 'activityChannel', messages
+      #
+      #   # Publish an array of Ably::Models::Message objects
+      #   messages = [
+      #     Ably::Models::Message(name: 'click', { x: 1, y: 2 })
+      #     Ably::Models::Message(name: 'click', { x: 2, y: 3 })
+      #   ]
+      #   client.publish 'activityChannel', messages
+      #
+      #   client.publish('activityChannel', 'click', 'body') do |message|
+      #     puts "#{message.name} event received with #{message.data}"
+      #   end
+      #
+      #   client.publish('activityChannel', 'click', 'body').errback do |error, message|
+      #     puts "#{message.name} was not received, error #{error.message}"
+      #   end
+      #
+      def publish(channel_name, name, data = nil, attributes = {}, &success_block)
+        if !connection.can_publish_messages?
+          error = Ably::Exceptions::MessageQueueingDisabled.new("Message cannot be published. Client is not allowed to queue of messages when connection is in state #{connection.state}")
+          return Ably::Util::SafeDeferrable.new_and_fail_immediately(logger, error)
+        end
+
+        messages = if name.kind_of?(Enumerable)
+          name
+        else
+          name = ensure_utf_8(:name, name, allow_nil: true)
+          ensure_supported_payload data
+          [{ name: name, data: data }.merge(attributes)]
+        end
+
+        if messages.length > Realtime::Connection::MAX_PROTOCOL_MESSAGE_BATCH_SIZE
+          error = Ably::Exceptions::InvalidRequest.new("It is not possible to publish more than #{Realtime::Connection::MAX_PROTOCOL_MESSAGE_BATCH_SIZE} messages with a single publish request.")
+          return Ably::Util::SafeDeferrable.new_and_fail_immediately(logger, error)
+        end
+
+        enqueue_messages_on_connection(self, messages, channel_name).tap do |deferrable|
+          deferrable.callback(&success_block) if block_given?
         end
       end
 

--- a/lib/ably/realtime/client/incoming_message_dispatcher.rb
+++ b/lib/ably/realtime/client/incoming_message_dispatcher.rb
@@ -102,7 +102,11 @@ module Ably::Realtime
               if channel.attached?
                 channel.manager.duplicate_attached_received protocol_message
               else
-                channel.transition_state_machine :attached, reason: protocol_message.error, resumed: protocol_message.has_channel_resumed_flag?, protocol_message: protocol_message
+                if channel.failed?
+                  logger.warn "Ably::Realtime::Client::IncomingMessageDispatcher - Received an ATTACHED protocol message for FAILED channel #{channel.name}. Ignoring ATTACHED message"
+                else
+                  channel.transition_state_machine :attached, reason: protocol_message.error, resumed: protocol_message.has_channel_resumed_flag?, protocol_message: protocol_message
+                end
               end
             end
 

--- a/lib/ably/realtime/connection.rb
+++ b/lib/ably/realtime/connection.rb
@@ -79,6 +79,9 @@ module Ably
         websocket_heartbeats_disabled: false,
       }.freeze
 
+      # Max number of messages to bundle in a single ProtocolMessage
+      MAX_PROTOCOL_MESSAGE_BATCH_SIZE = 50
+
       # A unique public identifier for this connection, used to identify this member in presence events and messages
       # @return [String]
       attr_reader :id

--- a/spec/acceptance/realtime/channel_spec.rb
+++ b/spec/acceptance/realtime/channel_spec.rb
@@ -1169,6 +1169,21 @@ describe Ably::Realtime::Channel, :event_machine do
         end
       end
 
+      context 'with more than allowed messages in a single publish' do
+        let(:channel_name) { random_str }
+
+        it 'rejects the publish' do
+          messages = (Ably::Realtime::Connection::MAX_PROTOCOL_MESSAGE_BATCH_SIZE + 1).times.map do
+            { name: 'foo' }
+          end
+
+          channel.publish(messages).errback do |error|
+            expect(error).to be_kind_of(Ably::Exceptions::InvalidRequest)
+            stop_reactor
+          end
+        end
+      end
+
       context 'identified clients' do
         context 'when authenticated with a wildcard client_id' do
           let(:token)            { Ably::Rest::Client.new(default_options).auth.request_token(client_id: '*') }

--- a/spec/acceptance/realtime/channel_spec.rb
+++ b/spec/acceptance/realtime/channel_spec.rb
@@ -838,28 +838,6 @@ describe Ably::Realtime::Channel, :event_machine do
         end
       end
 
-      context 'when the connection is not yet connected' do
-        it 'publishes queued messages within a single protocol message once connected' do
-          expect(connection.state).to eq(:initialized)
-          3.times { channel.publish('event', random_str) }
-          channel.subscribe do |message|
-            messages << message if message.name == 'event'
-            next unless messages.length == 3
-
-            # All 3 messages should be batched into a single Protocol Message by the client library
-            # message.id = "{protocol_message.id}:{protocol_message_index}"
-            # Check that all messages share the same protocol_message.id
-            message_id = messages.map { |msg| msg.id.split(':')[0...-1].join(':') }
-            expect(message_id.uniq.count).to eql(1)
-
-            # Check that messages use index 0,1,2 in the ID
-            message_indexes = messages.map { |msg| msg.id.split(':').last }
-            expect(message_indexes).to include("0", "1", "2")
-            stop_reactor
-          end
-        end
-      end
-
       context 'with :queue_messages client option set to false (#RTL6c4)' do
         let(:client_options)  { default_options.merge(queue_messages: false) }
 

--- a/spec/acceptance/realtime/client_spec.rb
+++ b/spec/acceptance/realtime/client_spec.rb
@@ -12,6 +12,7 @@ describe Ably::Realtime::Client, :event_machine do
     let(:auth_params)    { subject.auth.auth_params_sync }
 
     subject              { auto_close Ably::Realtime::Client.new(client_options) }
+    let(:sub_client)     { auto_close Ably::Realtime::Client.new(client_options) }
 
     context 'initialization' do
       context 'basic auth' do
@@ -292,6 +293,123 @@ describe Ably::Realtime::Client, :event_machine do
                   stop_reactor
                 end
               end
+            end
+          end
+        end
+      end
+    end
+
+    context '#publish (#TBC)' do
+      let(:channel_name) { random_str }
+      let(:channel)      { subject.channel(channel_name) }
+      let(:sub_channel)  { sub_client.channel(channel_name) }
+      let(:event_name)   { random_str }
+      let(:data)         { random_str }
+      let(:extras)       { { 'push' => { 'notification' => { 'title' => 'Testing' } } } }
+      let(:message)      { Ably::Models::Message.new(name: event_name, data: data) }
+
+      specify 'publishing a message implicity connects and publishes the message successfully on the provided channel' do
+        sub_channel.attach do
+          sub_channel.subscribe do |msg|
+            expect(msg.name).to eql(event_name)
+            expect(msg.data).to eql(data)
+            stop_reactor
+          end
+        end
+        subject.publish channel_name, event_name, data
+      end
+
+      specify 'publishing does not result in a channel being created' do
+        subject.publish channel_name, event_name, data
+        subject.channels.fetch(channel_name) do
+          # Block called if channel does not exist
+          EventMachine.add_timer(1) do
+            subject.channels.fetch(channel_name) do
+              # Block called if channel does not exist
+              stop_reactor
+            end
+          end
+        end
+      end
+
+      context 'with extras' do
+        let(:channel_name) { "pushenabled:#{random_str}" }
+
+        specify 'publishing supports extras' do
+          sub_channel.attach do
+            sub_channel.subscribe do |msg|
+              expect(msg.extras).to eql(extras)
+              stop_reactor
+            end
+          end
+          subject.publish channel_name, event_name, {}, extras: extras
+        end
+      end
+
+      specify 'publishing supports an array of Message objects' do
+        sub_channel.attach do
+          sub_channel.subscribe do |msg|
+            expect(msg.name).to eql(event_name)
+            expect(msg.data).to eql(data)
+            stop_reactor
+          end
+        end
+        subject.publish channel_name, [message]
+      end
+
+      specify 'publishing supports an array of Hash objects' do
+        sub_channel.attach do
+          sub_channel.subscribe do |msg|
+            expect(msg.name).to eql(event_name)
+            expect(msg.data).to eql(data)
+            stop_reactor
+          end
+        end
+        subject.publish channel_name, [name: event_name, data: data]
+      end
+
+      specify 'publishing on a closed connection fails' do
+        subject.connection.once(:connected) do
+          subject.connection.once(:closed) do
+            subject.publish(channel_name, name: event_name).errback do |error|
+              expect(error).to be_kind_of(Ably::Exceptions::MessageQueueingDisabled)
+              stop_reactor
+            end
+          end
+          connection.close
+        end
+      end
+
+      context 'queue_messages ClientOption' do
+        context 'when true' do
+          subject { auto_close Ably::Realtime::Client.new(client_options.merge(auto_connect: false)) }
+
+          it 'will queue messages whilst connecting and publish once connected' do
+            sub_channel.attach do
+              sub_channel.subscribe do |msg|
+                expect(msg.name).to eql(event_name)
+                stop_reactor
+              end
+              subject.connection.once(:connecting) do
+                subject.publish channel_name, event_name
+              end
+              subject.connection.connect
+            end
+          end
+        end
+
+        context 'when false' do
+          subject { auto_close Ably::Realtime::Client.new(client_options.merge(auto_connect: false, queue_messages: false)) }
+
+          it 'will reject messages on an initializing connection' do
+            sub_channel.attach do
+              subject.connection.once(:connecting) do
+                subject.publish(channel_name, event_name).errback do |error|
+                  expect(error).to be_kind_of(Ably::Exceptions::MessageQueueingDisabled)
+                  stop_reactor
+                end
+              end
+              subject.connection.connect
             end
           end
         end

--- a/spec/acceptance/realtime/client_spec.rb
+++ b/spec/acceptance/realtime/client_spec.rb
@@ -414,6 +414,21 @@ describe Ably::Realtime::Client, :event_machine do
           end
         end
       end
+
+      context 'with more than allowed messages in a single publish' do
+        let(:channel_name) { random_str }
+
+        it 'rejects the publish' do
+          messages = (Ably::Realtime::Connection::MAX_PROTOCOL_MESSAGE_BATCH_SIZE + 1).times.map do
+            { name: 'foo' }
+          end
+
+          subject.publish(channel_name, messages).errback do |error|
+            expect(error).to be_kind_of(Ably::Exceptions::InvalidRequest)
+            stop_reactor
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds support for transient publishing as defined in the spec atL:

* https://github.com/ably/docs/pull/323/files
* https://github.com/ably/docs/pull/470

I thought it would be useful to additionally see what's involved in support transient publishing from the proposed `Client#publish` method defined at https://github.com/ably/docs/issues/468.  Interested to hear your views on this.