### PR TITLE
Faraday 1.0 support test

### DIFF
--- a/ably.gemspec
+++ b/ably.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'eventmachine', '~> 1.2.6'
   spec.add_runtime_dependency 'em-http-request', '~> 1.1'
   spec.add_runtime_dependency 'statesman', '~> 1.0.0'
-  spec.add_runtime_dependency 'faraday', '~> 0.12'
+  spec.add_runtime_dependency 'faraday', '>= 0.12', '< 2.0.0'
   spec.add_runtime_dependency 'excon', '~> 0.55'
 
   if RUBY_VERSION.match(/^1\./)


### PR DESCRIPTION
Fixes https://github.com/ably/ably-ruby-rest/issues/11 by allowing more modern version of Faraday to be used
Fixes JWT error code issue https://github.com/ably/ably-ruby/issues/204