### PR TITLE
Update Travis CI versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,9 @@ env:
   - RSPEC_RETRY=true PARALLEL_TEST_PROCESSORS=2 PROTOCOL=msgpack
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.1.10
-  - 2.2.10
-  - 2.3.8
-  - 2.5.5
-  - 2.6.0
-  - 2.6.1
-  - 2.6.2
-  - 2.6.3
+  - 2.5.8
+  - 2.6.6
+  - 2.7.2
 script: spec/run_parallel_tests
 notifications:
   slack:


### PR DESCRIPTION
I know we're planning to Github workflows #208 but before that, following the discussion on Slack I've updated ruby to the current versions, removed redundant and EOL ones. I'll speed up our test suit a bit