### PR TITLE
Upgrade statesman

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,9 @@ env:
   - RSPEC_RETRY=true PARALLEL_TEST_PROCESSORS=2 PROTOCOL=msgpack
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.1.10
-  - 2.2.10
-  - 2.3.8
-  - 2.5.5
-  - 2.6.0
-  - 2.6.1
-  - 2.6.2
-  - 2.6.3
+  - 2.5.8
+  - 2.6.6
+  - 2.7.2
 script: spec/run_parallel_tests
 notifications:
   slack:

--- a/ably.gemspec
+++ b/ably.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'eventmachine', '~> 1.2.6'
   spec.add_runtime_dependency 'em-http-request', '~> 1.1'
-  spec.add_runtime_dependency 'statesman', '~> 1.0.0'
+  spec.add_runtime_dependency 'statesman', '~> 7.4'
   spec.add_runtime_dependency 'faraday', '>= 0.12', '< 2.0.0'
   spec.add_runtime_dependency 'excon', '~> 0.55'
 


### PR DESCRIPTION
Since all changes to statesman are related to ActiveRecord, we can easily update the version of statesman without any changes. This Mr is based https://github.com/ably/ably-ruby/pull/214 since statesman doesn't support EOL versions of Ruby.

Closes: https://github.com/ably/ably-ruby/issues/199