### PR TITLE
ClientId no longer forces token authentication

### DIFF
--- a/ably.gemspec
+++ b/ably.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |spec|
     spec.add_development_dependency 'webmock', '2.2'
     spec.add_development_dependency 'parallel_tests', '~> 2.9.0'
   else
-    spec.add_development_dependency 'webmock', '~> 2.2'
+    spec.add_development_dependency 'webmock', '~> 3.11'
     spec.add_development_dependency 'coveralls'
     spec.add_development_dependency 'parallel_tests', '~> 2.22'
     if !RUBY_VERSION.match(/^2\.[0123]/)

--- a/lib/ably/auth.rb
+++ b/lib/ably/auth.rb
@@ -103,7 +103,6 @@ module Ably
       end
 
       if has_client_id? && !token_creatable_externally? && !token_option
-        raise ArgumentError, 'client_id cannot be provided without a complete API key or means to authenticate. An API key is needed to automatically authenticate with Ably and obtain a token' unless api_key_present?
         @client_id = ensure_utf_8(:client_id, client_id) if client_id
       end
 
@@ -377,7 +376,7 @@ module Ably
     # True when Token Auth is being used to authenticate with Ably
     def using_token_auth?
       return options[:use_token_auth] if options.has_key?(:use_token_auth)
-      !!(token_option || current_token_details || has_client_id? || token_creatable_externally?)
+      !!(token_option || current_token_details || token_creatable_externally?)
     end
 
     def client_id
@@ -405,6 +404,17 @@ module Ably
         token_auth_header
       else
         basic_auth_header
+      end
+    end
+
+    # Extra headers that may be used during authentication
+    #
+    # @return [Hash] headers
+    def extra_auth_headers
+      if client_id && using_basic_auth?
+        { 'X-Ably-ClientId' => Base64.urlsafe_encode64(client_id) }
+      else
+        {}
       end
     end
 

--- a/lib/ably/rest/client.rb
+++ b/lib/ably/rest/client.rb
@@ -571,10 +571,9 @@ module Ably
             end
             unless options[:send_auth_header] == false
               request.headers[:authorization] = auth.auth_header
-              if options[:headers]
-                options[:headers].map do |key, val|
-                  request.headers[key] = val
-                end
+
+              options[:headers].to_h.merge(auth.extra_auth_headers).map do |key, val|
+                request.headers[key] = val
               end
             end
           end.tap do

--- a/spec/acceptance/realtime/client_spec.rb
+++ b/spec/acceptance/realtime/client_spec.rb
@@ -87,22 +87,6 @@ describe Ably::Realtime::Client, :event_machine do
                 end
               end
             end
-
-            context 'with client_id' do
-              let(:client_options) do
-                default_options.merge(client_id: random_str)
-              end
-              it 'connects using token auth' do
-                run_reactor do
-                  connection.on(:connected) do
-                    expect(connection.state).to eq(:connected)
-                    expect(auth_params[:access_token]).to_not be_nil
-                    expect(auth_params[:key]).to be_nil
-                    stop_reactor
-                  end
-                end
-              end
-            end
           end
         end
 

--- a/spec/acceptance/realtime/connection_spec.rb
+++ b/spec/acceptance/realtime/connection_spec.rb
@@ -77,18 +77,6 @@ describe Ably::Realtime::Connection, :event_machine do
                 end
               end
             end
-
-            context 'with implicit authorisation' do
-              let(:client_options) { default_options.merge(client_id: 'force_token_auth') }
-
-              it 'uses the token created by the implicit authorisation' do
-                expect(client.rest_client.auth).to receive(:request_token).once.and_call_original
-
-                connection.once(:connected) do
-                  stop_reactor
-                end
-              end
-            end
           end
 
           context 'that expire' do

--- a/spec/shared/client_initializer_behaviour.rb
+++ b/spec/shared/client_initializer_behaviour.rb
@@ -69,14 +69,6 @@ shared_examples 'a client initializer' do
         expect { subject }.to raise_error(ArgumentError, /key and key_name or key_secret are mutually exclusive/)
       end
     end
-
-    context 'client_id as only option' do
-      let(:client_options) { { client_id: 'valid' } }
-
-      it 'requires a valid key' do
-        expect { subject }.to raise_error(ArgumentError, /client_id cannot be provided without a complete API key or means to authenticate/)
-      end
-    end
   end
 
   context 'with valid arguments' do


### PR DESCRIPTION
Resolves: https://github.com/ably/ably-ruby/issues/182