### PR TITLE
Update attach_serial before emiting UPDATE event

### DIFF
--- a/lib/ably/realtime/channel/channel_manager.rb
+++ b/lib/ably/realtime/channel/channel_manager.rb
@@ -63,6 +63,8 @@ module Ably::Realtime
           log_channel_error protocol_message.error
         end
 
+        channel.properties.set_attach_serial(protocol_message.channel_serial)
+
         if protocol_message.has_channel_resumed_flag?
           logger.debug { "ChannelManager: Additional resumed ATTACHED message received for #{channel.state} channel '#{channel.name}'" }
         else
@@ -75,8 +77,6 @@ module Ably::Realtime
           )
           update_presence_sync_state_following_attached protocol_message
         end
-
-        channel.properties.set_attach_serial(protocol_message.channel_serial)
       end
 
       # Handle DETACED messages, see #RTL13 for server-initated detaches


### PR DESCRIPTION
Based on https://github.com/ably/ably-ruby/pull/227 because it uses channel properties. So please, check only 8da823e0f404737f3667ca114917246bfae7a630

Resolves: https://github.com/ably/ably-ruby/issues/113

Added separate test specifically for
> also check that UPDATE updates serial