### PR TITLE
Set SNI hostname and verify peer certificates when using TLS

### DIFF
--- a/lib/ably/realtime/connection/websocket_transport.rb
+++ b/lib/ably/realtime/connection/websocket_transport.rb
@@ -16,10 +16,13 @@ module Ably::Realtime
       )
       include Ably::Modules::StateEmitter
 
+      attr_reader :host
+
       def initialize(connection, url)
         @connection = connection
         @state      = STATE.Initialized
         @url        = url
+        @host       = URI.parse(url).hostname
 
         setup_event_handlers
       end
@@ -49,7 +52,7 @@ module Ably::Realtime
       # Required {http://www.rubydoc.info/github/eventmachine/eventmachine/EventMachine/Connection EventMachine::Connection} interface
       def connection_completed
         change_state STATE.Connected
-        start_tls if client.use_tls?
+        start_tls(tls_opts) if client.use_tls?
         driver.start
       end
 
@@ -213,6 +216,15 @@ module Ably::Realtime
             :protocol_message
           end
         )
+      end
+
+      # TLS options to pass to EventMachine::Connection#start_tls
+      #
+      # See https://www.rubydoc.info/github/eventmachine/eventmachine/EventMachine/Connection#start_tls-instance_method
+      def tls_opts
+        {
+          sni_hostname: host,
+        }
       end
     end
   end


### PR DESCRIPTION
This updates the WebSocket transport to set the SNI hostname when using TLS to ensure clients can connect to endpoints that require SNI, and to always verify the peer certificate to ensure clients are connecting to trusted endpoints.

I've tested the verification manually by attempting to connect to `wrong.host.badssl.com` (which returns a certificate with a different hostname), and the Ably client now reports an error and refuses to connect:

```ruby
require 'eventmachine'
require 'ably'
EventMachine.run do
  client = Ably::Realtime.new(
    rest_host:     'wrong.host.badssl.com',
    realtime_host: 'wrong.host.badssl.com',
    key:           ENV['ABLY_KEY'],
    log_level:     :debug,
  )
  client.connection.connect do
    p "connected!"
  end
end
```

```
12:01:49.094 DEBUG [ -- ] Ably::Realtime::Connection: Transitioned to connecting
12:01:49.094 DEBUG [ -- ] Ably::Realtime::Connection: StateEmitter changed from STATE.Initialized => connecting
12:01:49.094 DEBUG [ -- ] ConnectionManager: Opening a websocket transport connection
12:01:49.097 DEBUG [ -- ] ConnectionManager: Setting up automatic connection timeout timer for 10s
12:01:49.097 DEBUG [ -- ] Connection: Opening socket connection to wrong.host.badssl.com:443/?key=xxx&format=msgpack&echo=true&v=1.1&lib=ruby-1.1.3&heartbeats=false
12:01:49.097 DEBUG [ -- ] Connection: EventMachine connecting to wrong.host.badssl.com:443 with URL: wss://wrong.host.badssl.com:443?key=xxx&format=msgpack&echo=true&v=1.1&lib=ruby-1.1.3&heartbeats=false
12:01:49.099 DEBUG [ -- ] Ably::Realtime::Connection::WebsocketTransport: StateEmitter changed from STATE.Initialized => STATE.Connecting
12:01:49.219 DEBUG [ -- ] Ably::Realtime::Connection::WebsocketTransport: StateEmitter changed from STATE.Connecting => STATE.Connected
2021-04-16 12:01:49.474 ERROR [ -- ] WebsocketTransport: Disconnecting due to error: Websocket host 'wrong.host.badssl.com' returned an invalid TLS certificate
12:01:49.474 DEBUG [ -- ] Ably::Realtime::Connection::WebsocketTransport: StateEmitter changed from STATE.Connected => STATE.Disconnecting
12:01:49.475 DEBUG [ -- ] Ably::Realtime::Connection::WebsocketTransport: StateEmitter changed from STATE.Disconnecting => STATE.Disconnected
12:01:49.475 DEBUG [ -- ] Ably::Realtime::Connection: Transitioned from connecting => disconnected
12:01:49.476 DEBUG [ -- ] Ably::Realtime::Connection: StateEmitter changed from STATE.Connecting => disconnected

```