### PR TITLE
Upgrade statesman to ~> 8.0

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,7 +10,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        ruby: [ '2.5', '2.6', '2.7' ]
+        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
         protocol: [ 'json', 'msgpack' ]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,7 +10,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
+        ruby: [ '2.5', '2.6', '2.7' ]
         protocol: [ 'json', 'msgpack' ]
     steps:
       - uses: actions/checkout@v2

--- a/ably.gemspec
+++ b/ably.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'eventmachine', '~> 1.2.6'
   spec.add_runtime_dependency 'em-http-request', '~> 1.1'
-  spec.add_runtime_dependency 'statesman', '~> 7.4'
+  spec.add_runtime_dependency 'statesman', '~> 8.0'
   spec.add_runtime_dependency 'faraday', '>= 0.12', '< 2.0.0'
   spec.add_runtime_dependency 'excon', '~> 0.55'
 


### PR DESCRIPTION
statesman is on 8.x now which fixes a Rails 6.1 related deprecation.

In [v8.0.0 on Jan 6](https://github.com/gocardless/statesman/blob/master/CHANGELOG.md#v800-6th-january-2021) they fixed a deprecation, specifically [Use AR Arel table to type cast booleans in order to avoid deprecation warning #421](https://github.com/gocardless/statesman/pull/421)

Without this you get a bunch of deprecation messages, and obviously it'll stop working in Rails 6.2 as the deprecation points out.

This change allows the use of the 8.x line of stateman with ably so that we can upgrade to versions with the fix.