### PR TITLE
Implement RSC7d (Ably-Agent header)

### DIFF
--- a/lib/ably.rb
+++ b/lib/ably.rb
@@ -1,6 +1,7 @@
 require 'addressable/uri'
 
 require 'ably/version'
+require 'ably/agent'
 
 %w(modules util).each do |namespace|
   Dir.glob(File.expand_path("ably/#{namespace}/*.rb", File.dirname(__FILE__))).sort.each do |file|

--- a/lib/ably/agent.rb
+++ b/lib/ably/agent.rb
@@ -1,0 +1,4 @@
+module Ably
+  # Default Ably Agent
+  AGENT = "ably-ruby/#{Ably::VERSION}"
+end

--- a/lib/ably/agent.rb
+++ b/lib/ably/agent.rb
@@ -1,4 +1,3 @@
 module Ably
-  # Default Ably Agent
-  AGENT = "ably-ruby/#{Ably::VERSION}"
+  AGENT = "ably-ruby/#{Ably::VERSION} ruby/#{RUBY_VERSION}"
 end

--- a/lib/ably/realtime/connection.rb
+++ b/lib/ably/realtime/connection.rb
@@ -434,7 +434,7 @@ module Ably
                 'format' =>     client.protocol,
                 'echo' =>       client.echo_messages,
                 'v' =>          Ably::PROTOCOL_VERSION,
-                'lib' =>        client.rest_client.lib_version_id,
+                'agent' =>      client.rest_client.agent
               )
 
               # Use native websocket heartbeats if possible, but allow Ably protocol heartbeats

--- a/lib/ably/rest/client.rb
+++ b/lib/ably/rest/client.rb
@@ -42,9 +42,6 @@ module Ably
         Faraday::ClientError
       end
 
-      # Default Ably Agent
-      AGENT = "ably-ruby/#{Ably::VERSION}"
-
       def_delegators :auth, :client_id, :auth_options
 
       # Custom environment to use such as 'sandbox' when testing the client library against an alternate Ably environment
@@ -175,7 +172,7 @@ module Ably
           end
         end
 
-        @agent               = options.delete(:agent) || AGENT
+        @agent               = options.delete(:agent) || Ably::AGENT
         @realtime_client     = options.delete(:realtime_client)
         @tls                 = options.delete(:tls) == false ? false : true
         @environment         = options.delete(:environment) # nil is production

--- a/lib/ably/rest/client.rb
+++ b/lib/ably/rest/client.rb
@@ -42,6 +42,9 @@ module Ably
         Faraday::ClientError
       end
 
+      # Default Ably Agent
+      AGENT = "ably-ruby/#{Ably::VERSION}"
+
       def_delegators :auth, :client_id, :auth_options
 
       # Custom environment to use such as 'sandbox' when testing the client library against an alternate Ably environment
@@ -51,6 +54,10 @@ module Ably
       # The protocol configured for this client, either binary `:msgpack` or text based `:json`
       # @return [Symbol]
       attr_reader :protocol
+
+      # Client agent i.e. `example-gem/1.2.0 ably-ruby/1.1.5 ruby/1.9.3`
+      # @return [String]
+      attr_reader :agent
 
       # {Ably::Auth} authentication object configured for this connection
       # @return [Ably::Auth]
@@ -168,6 +175,7 @@ module Ably
           end
         end
 
+        @agent               = options.delete(:agent) || AGENT
         @realtime_client     = options.delete(:realtime_client)
         @tls                 = options.delete(:tls) == false ? false : true
         @environment         = options.delete(:environment) # nil is production
@@ -663,7 +671,8 @@ module Ably
             accept:             mime_type,
             user_agent:         user_agent,
             'X-Ably-Version' => Ably::PROTOCOL_VERSION,
-            'X-Ably-Lib'     => lib_version_id
+            'X-Ably-Lib'     => lib_version_id,
+            'Ably-Agent'     => agent
           },
           request: {
             open_timeout: http_defaults.fetch(:open_timeout),

--- a/lib/ably/rest/client.rb
+++ b/lib/ably/rest/client.rb
@@ -481,16 +481,6 @@ module Ably
         end
       end
 
-      # Library Ably version user agent
-      # @api private
-      def lib_version_id
-        @lib_version_id ||= [
-          'ruby',
-          Ably.lib_variant,
-          Ably::VERSION
-        ].compact.join('-')
-      end
-
       # Allowable duration for an external auth request
       # For REST client this defaults to request_timeout
       # For Realtime clients this defaults to 250ms less than the realtime_request_timeout
@@ -671,7 +661,6 @@ module Ably
             accept:             mime_type,
             user_agent:         user_agent,
             'X-Ably-Version' => Ably::PROTOCOL_VERSION,
-            'X-Ably-Lib'     => lib_version_id,
             'Ably-Agent'     => agent
           },
           request: {

--- a/lib/ably/version.rb
+++ b/lib/ably/version.rb
@@ -2,18 +2,6 @@ module Ably
   VERSION = '1.1.5'
   PROTOCOL_VERSION = '1.1'
 
-  # Allow a variant to be configured for all instances of this client library
-  # such as ruby-rest-[VERSION]
-
-  # @api private
-  def self.lib_variant=(variant)
-    @lib_variant = variant
-  end
-
-  def self.lib_variant
-    @lib_variant
-  end
-
   # @api private
   def self.major_minor_version_numeric
     VERSION.gsub(/\.\d+$/, '').to_f

--- a/spec/acceptance/realtime/connection_spec.rb
+++ b/spec/acceptance/realtime/connection_spec.rb
@@ -1843,7 +1843,7 @@ describe Ably::Realtime::Connection, :event_machine do
       it 'sends the lib version param agent (#RCS7d)' do
         expect(EventMachine).to receive(:connect) do |host, port, transport, object, url|
           uri = URI.parse(url)
-          expect(CGI::parse(uri.query)['agent'][0]).to match(/^ably-ruby\/\d\.\d\.\d$/)
+          expect(CGI::parse(uri.query)['agent'][0]).to match(/^ably-ruby\/\d\.\d\.\d ruby\/\d\.\d\.\d$/)
           stop_reactor
         end
         client

--- a/spec/acceptance/realtime/connection_spec.rb
+++ b/spec/acceptance/realtime/connection_spec.rb
@@ -1840,34 +1840,13 @@ describe Ably::Realtime::Connection, :event_machine do
         client
       end
 
-      it 'sends the lib version param lib (#RTN2g)' do
+      it 'sends the lib version param agent (#RCS7d)' do
         expect(EventMachine).to receive(:connect) do |host, port, transport, object, url|
           uri = URI.parse(url)
-          expect(CGI::parse(uri.query)['lib'][0]).to match(/^ruby-1\.1\.\d+(-[\w\.]+)?+$/)
+          expect(CGI::parse(uri.query)['agent'][0]).to match(/^ably-ruby\/\d\.\d\.\d$/)
           stop_reactor
         end
         client
-      end
-
-      context 'with variant' do
-        let(:variant) { 'foo' }
-
-        before do
-          Ably.lib_variant = variant
-        end
-
-        after do
-          Ably.lib_variant = nil
-        end
-
-        it 'sends the lib version param lib with the variant (#RTN2g + #RSC7b)' do
-          expect(EventMachine).to receive(:connect) do |host, port, transport, object, url|
-            uri = URI.parse(url)
-            expect(CGI::parse(uri.query)['lib'][0]).to match(/^ruby-#{variant}-1\.1\.\d+(-[\w\.]+)?$/)
-            stop_reactor
-          end
-          client
-        end
       end
     end
 

--- a/spec/acceptance/rest/client_spec.rb
+++ b/spec/acceptance/rest/client_spec.rb
@@ -1081,29 +1081,15 @@ describe Ably::Rest::Client do
     end
 
     context 'version headers', :webmock do
-      [nil, 'foo'].each do |variant|
-        context "with variant #{variant ? variant : 'none'}" do
-          if variant
-            before do
-              Ably.lib_variant = variant
-            end
+      [nil, 'ably-ruby/1.1.1 ruby/1.9.3'].each do |agent|
+        context "with #{agent ? "custom #{agent}" : 'default'} agent" do
+          let(:client_options) { default_options.merge(key: api_key, agent: agent) }
 
-            after do
-              Ably.lib_variant = nil
-            end
-          end
-
-          let(:client_options) { default_options.merge(key: api_key) }
           let!(:publish_message_stub) do
-            lib = ['ruby']
-            lib << variant if variant
-            lib << Ably::VERSION
-
-
             stub_request(:post, "#{client.endpoint}/channels/foo/publish").
               with(headers: {
                 'X-Ably-Version' => Ably::PROTOCOL_VERSION,
-                'X-Ably-Lib' => lib.join('-')
+                'Ably-Agent' => agent || Ably::AGENT
               }).
               to_return(status: 201, body: '{}', headers: { 'Content-Type' => 'application/json' })
           end

--- a/spec/unit/rest/client_spec.rb
+++ b/spec/unit/rest/client_spec.rb
@@ -44,7 +44,7 @@ describe Ably::Rest::Client do
           let(:client_options) { { key: 'appid.keyuid:keysecret' } }
 
           it 'should return default ably agent' do
-            expect(subject.agent).to eq(Ably::Rest::Client::AGENT)
+            expect(subject.agent).to eq(Ably::AGENT)
           end
         end
 

--- a/spec/unit/rest/client_spec.rb
+++ b/spec/unit/rest/client_spec.rb
@@ -38,6 +38,26 @@ describe Ably::Rest::Client do
       end
     end
 
+    context 'use agent' do
+      context 'set agent to non-default value' do
+        context 'default agent' do
+          let(:client_options) { { key: 'appid.keyuid:keysecret' } }
+
+          it 'should return default ably agent' do
+            expect(subject.agent).to eq(Ably::Rest::Client::AGENT)
+          end
+        end
+
+        context 'custom agent' do
+          let(:client_options) { { key: 'appid.keyuid:keysecret', agent: 'example-gem/1.1.4 ably-ruby/1.1.5 ruby/3.0.0' } }
+
+          it 'should overwrite client.agent' do
+            expect(subject.agent).to eq('example-gem/1.1.4 ably-ruby/1.1.5 ruby/3.0.0')
+          end
+        end
+      end
+    end
+
     context ':use_token_auth' do
       context 'set to false' do
         context 'with a key and :tls => false' do


### PR DESCRIPTION
#230 

https://github.com/ably/docs/pull/1034

- Removed `X-Ably-Lib` header param
- Added `Ably-Agent` header param to the REST client headers
- overwrite agent for example `Ably::Rest::Client.new(agent: 'ably-ruby/1.1.5 ruby/1.9.3')`
- Added `agent` parameter to the realtime client connection auth_deferrable params
- Removed `Ably.lib_variant`
- Added `Ably::AGENT` in `lib/ably/agent.rb`
- Fixed specs
- Updated `ably-ruby-rest` https://github.com/ably/ably-ruby-rest/pull/17