### PR TITLE
Update client options support to 1.1 spec level (maxMessageSize)

### DIFF
--- a/lib/ably/exceptions.rb
+++ b/lib/ably/exceptions.rb
@@ -52,6 +52,9 @@ module Ably
       end
     end
 
+    # Maximum message size exceeded TO3l8
+    class MaxMessageSizeExceeded < BaseAblyException; end
+
     # An invalid request was received by Ably
     class InvalidRequest < BaseAblyException; end
 

--- a/lib/ably/models/connection_details.rb
+++ b/lib/ably/models/connection_details.rb
@@ -38,6 +38,7 @@ module Ably::Models
           self.attributes[duration_field] = (self.attributes[duration_field].to_f / 1000).round
         end
       end
+      self.attributes[:max_message_size] ||= 65536
       self.attributes.freeze
     end
 

--- a/lib/ably/models/message.rb
+++ b/lib/ably/models/message.rb
@@ -105,6 +105,20 @@ module Ably::Models
       end.to_json
     end
 
+    # The size is the sum over name, data, clientId, and extras in bytes (TO3l8a)
+    #
+    def size
+      %w(name data client_id extras).map do |attr|
+        if (value = attributes[attr.to_sym]).is_a?(String)
+          value.bytesize
+        elsif value.nil?
+          0
+        else
+          value.to_json.bytesize
+        end
+      end.sum
+    end
+
     # Assign this message to a ProtocolMessage before delivery to the Ably system
     # @api private
     def assign_to_protocol_message(protocol_message)

--- a/lib/ably/models/presence_message.rb
+++ b/lib/ably/models/presence_message.rb
@@ -125,6 +125,20 @@ module Ably::Models
       end.to_json
     end
 
+    # The size is the sum over data and clientId in bytes (TO3l8a)
+    #
+    def size
+      %w(data client_id).map do |attr|
+        if (value = attributes[attr.to_sym]).is_a?(String)
+          value.bytesize
+        elsif value.nil?
+          0
+        else
+          value.to_json.bytesize
+        end
+      end.sum
+    end
+
     # Assign this presence message to a ProtocolMessage before delivery to the Ably system
     # @api private
     def assign_to_protocol_message(protocol_message)

--- a/lib/ably/models/protocol_message.rb
+++ b/lib/ably/models/protocol_message.rb
@@ -185,6 +185,14 @@ module Ably::Models
         end
     end
 
+    def message_size
+      presence.map(&:size).sum + messages.map(&:size).sum
+    end
+
+    def has_correct_message_size?
+      message_size <= connection_details.max_message_size
+    end
+
     def flags
       Integer(attributes[:flags])
     rescue TypeError

--- a/lib/ably/realtime/channel/publisher.rb
+++ b/lib/ably/realtime/channel/publisher.rb
@@ -22,6 +22,11 @@ module Ably::Realtime
           end
         end
 
+        if messages.sum(&:size) > Ably::Realtime::Connection::MAX_MESSAGE_SIZE
+          error = Ably::Exceptions::MaxMessageSizeExceeded.new("Message size exceeded #{Ably::Realtime::Connection::MAX_MESSAGE_SIZE} bytes.")
+          return Ably::Util::SafeDeferrable.new_and_fail_immediately(logger, error)
+        end
+
         connection.send_protocol_message(
           action:   Ably::Models::ProtocolMessage::ACTION.Message.to_i,
           channel:  channel_name,

--- a/lib/ably/realtime/client/incoming_message_dispatcher.rb
+++ b/lib/ably/realtime/client/incoming_message_dispatcher.rb
@@ -121,15 +121,23 @@ module Ably::Realtime
             presence.manager.sync_process_messages protocol_message.channel_serial, protocol_message.presence
 
           when ACTION.Presence
-            presence = get_channel(protocol_message.channel).presence
-            protocol_message.presence.each do |presence_message|
-              presence.__incoming_msgbus__.publish :presence, presence_message
+            if protocol_message.has_correct_message_size?
+              presence = get_channel(protocol_message.channel).presence
+              protocol_message.presence.each do |presence_message|
+                presence.__incoming_msgbus__.publish :presence, presence_message
+              end
+            else
+              logger.fatal Ably::Exceptions::ProtocolError.new("Not published. Channel message limit exceeded #{protocol_message.message_size} bytes", 400, Ably::Exceptions::Codes::UNABLE_TO_RECOVER_CHANNEL_MESSAGE_LIMIT_EXCEEDED).message
             end
 
           when ACTION.Message
-            channel = get_channel(protocol_message.channel)
-            protocol_message.messages.each do |message|
-              channel.__incoming_msgbus__.publish :message, message
+            if protocol_message.has_correct_message_size?
+              channel = get_channel(protocol_message.channel)
+              protocol_message.messages.each do |message|
+                channel.__incoming_msgbus__.publish :message, message
+              end
+            else
+              logger.fatal Ably::Exceptions::ProtocolError.new("Not published. Channel message limit exceeded #{protocol_message.message_size} bytes", 400, Ably::Exceptions::Codes::UNABLE_TO_RECOVER_CHANNEL_MESSAGE_LIMIT_EXCEEDED).message
             end
 
           when ACTION.Auth

--- a/lib/ably/realtime/connection.rb
+++ b/lib/ably/realtime/connection.rb
@@ -82,6 +82,9 @@ module Ably
       # Max number of messages to bundle in a single ProtocolMessage
       MAX_PROTOCOL_MESSAGE_BATCH_SIZE = 50
 
+      # Max message size
+      MAX_MESSAGE_SIZE = 65536 # See spec TO3l8
+
       # A unique public identifier for this connection, used to identify this member in presence events and messages
       # @return [String]
       attr_reader :id

--- a/spec/acceptance/realtime/channel_spec.rb
+++ b/spec/acceptance/realtime/channel_spec.rb
@@ -1403,6 +1403,20 @@ describe Ably::Realtime::Channel, :event_machine do
           end
         end
       end
+
+      context 'message size exceeded (#TO3l8)' do
+        let(:data) { { data: 'x' * 700000 } }
+
+        it 'should not allow to send a message' do
+          channel.publish([{ data: data }]).tap do |deferrable|
+            deferrable.errback do |error|
+              expect(error.message).to match(/^Maximum\ message\ length\ exceeded/)
+              expect(error.href).to eq('https://help.ably.io/error/40009')
+              stop_reactor
+            end
+          end
+        end
+      end
     end
 
     describe '#subscribe' do

--- a/spec/acceptance/realtime/channel_spec.rb
+++ b/spec/acceptance/realtime/channel_spec.rb
@@ -1405,15 +1405,15 @@ describe Ably::Realtime::Channel, :event_machine do
       end
 
       context 'message size exceeded (#TO3l8)' do
-        let(:data) { { data: 'x' * 700000 } }
+        let(:message) { 'x' * 700000 }
+
+        let(:client) { auto_close Ably::Realtime::Client.new(client_options) }
+        let(:channel) { client.channels.get(channel_name) }
 
         it 'should not allow to send a message' do
-          channel.publish([{ data: data }]).tap do |deferrable|
-            deferrable.errback do |error|
-              expect(error.message).to match(/^Maximum\ message\ length\ exceeded/)
-              expect(error.href).to eq('https://help.ably.io/error/40009')
-              stop_reactor
-            end
+          channel.publish('event', message).errback do |error|
+            expect(error).to be_instance_of(Ably::Exceptions::MaxMessageSizeExceeded)
+            stop_reactor
           end
         end
       end

--- a/spec/acceptance/rest/channel_spec.rb
+++ b/spec/acceptance/rest/channel_spec.rb
@@ -60,6 +60,8 @@ describe Ably::Rest::Channel do
         end
 
         it 'publishes an array of messages in one HTTP request' do
+          expect(messages.sum(&:size) < Ably::Rest::Channel::MAX_MESSAGE_SIZE).to eq(true)
+
           expect(client).to receive(:post).once.and_call_original
           expect(channel.publish(messages)).to eql(true)
           expect(channel.history.items.map(&:name)).to match_array(messages.map { |message| message[:name] })
@@ -75,6 +77,8 @@ describe Ably::Rest::Channel do
         end
 
         it 'publishes an array of messages in one HTTP request' do
+          expect(messages.sum(&:size) < Ably::Rest::Channel::MAX_MESSAGE_SIZE).to eq(true)
+
           expect(client).to receive(:post).once.and_call_original
           expect(channel.publish(messages)).to eql(true)
           expect(channel.history.items.map(&:name)).to match_array(messages.map(&:name))

--- a/spec/acceptance/rest/channel_spec.rb
+++ b/spec/acceptance/rest/channel_spec.rb
@@ -354,6 +354,15 @@ describe Ably::Rest::Channel do
           end
         end
       end
+
+      context 'max message size is exceeded (#TO3l8)' do
+        let(:data) { 101.times.map { { data: 'x' * 655 } } }
+
+        it 'should raise Ably::Exceptions::MaxMessageSizeExceeded exception' do
+          expect { channel.publish([ data: data ]) }.to \
+            raise_error(Ably::Exceptions::MaxMessageSizeExceeded)
+        end
+      end
     end
 
     describe '#history' do

--- a/spec/acceptance/rest/channel_spec.rb
+++ b/spec/acceptance/rest/channel_spec.rb
@@ -355,7 +355,7 @@ describe Ably::Rest::Channel do
         end
       end
 
-      context 'max message size is exceeded (#TO3l8)' do
+      context 'message size is exceeded (#TO3l8)' do
         let(:data) { 101.times.map { { data: 'x' * 655 } } }
 
         it 'should raise Ably::Exceptions::MaxMessageSizeExceeded exception' do

--- a/spec/shared/model_behaviour.rb
+++ b/spec/shared/model_behaviour.rb
@@ -19,7 +19,7 @@ shared_examples 'a model' do |shared_options = {}|
     end
 
     context '#attributes', :api_private do
-      let(:model_options) { { action: 5 } }
+      let(:model_options) { { action: 5, max_message_size: 65536 } }
 
       it 'provides access to #attributes' do
         expect(model.attributes).to eq(model_options)

--- a/spec/unit/models/message_spec.rb
+++ b/spec/unit/models/message_spec.rb
@@ -211,6 +211,65 @@ describe Ably::Models::Message do
     end
   end
 
+  describe '#size' do
+    let(:model) { subject.new({ name: name, data: data, client_id: client_id, extras: extras }, protocol_message: protocol_message) }
+
+    context 'String (#TO3l8a)' do
+      let(:data) { 'example string data' }
+      let(:client_id) { '1' }
+      let(:name) { 'My Name' }
+      let(:extras) { 'extras' }
+
+      it 'should return 33 bytes' do
+        expect(model.size).to eq(33)
+      end
+    end
+
+    context 'Object (#TO3l8b)' do
+      let(:data) { Object.new }
+      let(:client_id) { String('10') }
+      let(:name) { 'John' }
+      let(:extras) { Hash.new }
+
+      it 'should return 38 bytes' do
+        expect(model.size).to eq(38)
+      end
+    end
+
+    context 'Array (#TO3l8b)' do
+      let(:data) { [1, 'two', :three] }
+      let(:client_id) { '2' }
+      let(:name) { 'Kate' }
+      let(:extras) { [] }
+
+      it 'should return 24 bytes' do
+        expect(model.size).to eq(24)
+      end
+    end
+
+    context 'extras (#TO3l8d)' do
+      let(:data) { { example: 'value', score: 1, hash: { test: true } } }
+      let(:client_id) { '3' }
+      let(:name) { 'John' }
+      let(:extras) { {} }
+
+      it 'should return 57 bytes' do
+        expect(model.size).to eq(57)
+      end
+    end
+
+    context 'nil (#TO3l8e)' do
+      let(:data) { nil }
+      let(:client_id) { '' }
+      let(:name) { '' }
+      let(:extras) { nil}
+
+      it 'should return 19 bytes' do
+        expect(model.size).to eq(0)
+      end
+    end
+  end
+
   context 'from REST request with embedded fields', :api_private do
     let(:id)                  { random_str }
     let(:protocol_message_id) { random_str }

--- a/spec/unit/models/presence_message_spec.rb
+++ b/spec/unit/models/presence_message_spec.rb
@@ -220,6 +220,55 @@ describe Ably::Models::PresenceMessage do
     end
   end
 
+  describe '#size' do
+    let(:model) { subject.new({ action: 'enter', data: data, client_id: client_id }, protocol_message: protocol_message) }
+
+    context 'String (#TO3l8a)' do
+      let(:data) { 'example string data' }
+      let(:client_id) { '1' }
+
+      it 'should return 20 bytes' do
+        expect(model.size).to eq(20)
+      end
+    end
+
+    context 'Object (#TO3l8b)' do
+      let(:data) { Object.new }
+      let(:client_id) { '10' }
+
+      it 'should return 32 bytes' do
+        expect(model.size).to eq(32)
+      end
+    end
+
+    context 'Array (#TO3l8b)' do
+      let(:data) { [1, 'two', :three] }
+      let(:client_id) { '2' }
+
+      it 'should return 18 bytes' do
+        expect(model.size).to eq(18)
+      end
+    end
+
+    context 'extras (#TO3l8d)' do
+      let(:data) { { example: 'value', score: 1, hash: { test: true } } }
+      let(:client_id) { '3' }
+
+      it 'should return 51 bytes' do
+        expect(model.size).to eq(51)
+      end
+    end
+
+    context 'nil (#TO3l8e)' do
+      let(:data) { nil }
+      let(:client_id) { '4' }
+
+      it 'should return 1 bytes' do
+        expect(model.size).to eq(1)
+      end
+    end
+  end
+
   context 'from REST request with embedded fields', :api_private do
     let(:id) { random_str }
     let(:message_time) { Time.now + 60 }

--- a/spec/unit/models/protocol_message_spec.rb
+++ b/spec/unit/models/protocol_message_spec.rb
@@ -318,6 +318,54 @@ describe Ably::Models::ProtocolMessage do
       end
     end
 
+    context '#message_size (#TO3l8)' do
+      context 'on presence' do
+        let(:protocol_message) do
+          new_protocol_message(presence: [{ action: 1, data: 'test342343', client_id: 'sdf' }])
+        end
+
+        it 'should return 13 bytes (sum in bytes: data and client_id)' do
+          expect(protocol_message.message_size).to eq(13)
+        end
+      end
+
+      context 'on message' do
+        let(:protocol_message) do
+          new_protocol_message(messages: [{ action: 1, unknown: 'test', data: 'test342343', client_id: 'sdf', name: 'sf23ewrew', extras: { time: Time.now, time_zone: 'UTC' } }])
+        end
+
+        it 'should return 76 bytes (sum in bytes: data, client_id, name, extras)' do
+          expect(protocol_message.message_size).to eq(76)
+        end
+      end
+    end
+
+    context '#has_correct_message_size? (#TO3l8)' do
+      context 'on presence' do
+        it 'should return true when a message has correct size' do
+          protocol_message = new_protocol_message(presence: [{ action: 1, data: 'x' * 100 }])
+          expect(protocol_message.has_correct_message_size?).to eq(true)
+        end
+
+        it 'should return false when a message has not correct size' do
+          protocol_message = new_protocol_message(presence: [{ action: 1, data: 'x' * 65537 }])
+          expect(protocol_message.has_correct_message_size?).to eq(false)
+        end
+      end
+
+      context 'on message' do
+        it 'should return true when a message has correct size' do
+          protocol_message = new_protocol_message(messages: [{ name: 'x' * 100 }])
+          expect(protocol_message.has_correct_message_size?).to eq(true)
+        end
+
+        it 'should return false when a message has not correct size' do
+          protocol_message = new_protocol_message(messages: [{ name: 'x' * 65537 }])
+          expect(protocol_message.has_correct_message_size?).to eq(false)
+        end
+      end
+    end
+
     context '#connection_details (#TR4o)' do
       let(:connection_details) { protocol_message.connection_details }
 

--- a/spec/unit/realtime/channel_spec.rb
+++ b/spec/unit/realtime/channel_spec.rb
@@ -68,7 +68,7 @@ describe Ably::Realtime::Channel do
 
   describe '#publish name argument' do
     let(:encoded_value) { random_str.encode(encoding) }
-    let(:message) { instance_double('Ably::Models::Message', client_id: nil) }
+    let(:message) { instance_double('Ably::Models::Message', client_id: nil, size: 0) }
 
     before do
       allow(subject).to receive(:create_message).and_return(message)

--- a/spec/unit/realtime/incoming_message_dispatcher_spec.rb
+++ b/spec/unit/realtime/incoming_message_dispatcher_spec.rb
@@ -32,5 +32,43 @@ describe Ably::Realtime::Client::IncomingMessageDispatcher, :api_private do
       expect(subject).to receive_message_chain(:logger, :warn)
       msgbus.publish :protocol_message, Ably::Models::ProtocolMessage.new(:action => :attached, channel: 'unknown')
     end
+
+    context 'TO3l8' do
+      context 'on action presence' do
+        let(:presence) { 101.times.map { { data: 'x' * 655 } } }
+
+        let(:protocol_message) do
+          Ably::Models::ProtocolMessage.new(action: :presence, channel: 'default', presence: presence, connection_serial: 123123123)
+        end
+
+        it 'should raise a protocol error when message size exceeded 65536 bytes' do
+          allow(connection).to receive(:serial).and_return(12312312)
+          allow(subject).to receive(:update_connection_recovery_info)
+          allow(subject).to receive_message_chain(:logger, :debug)
+          allow(subject).to receive_message_chain(:logger, :warn)
+          expect(subject).to receive_message_chain(:logger, :fatal)
+
+          msgbus.publish :protocol_message, protocol_message
+        end
+      end
+
+      context 'on action message' do
+        let(:messages) { 101.times.map { { data: 'x' * 655 } } }
+
+        let(:protocol_message) do
+          Ably::Models::ProtocolMessage.new(action: :message, channel: 'default', messages: messages, connection_serial: 123123123)
+        end
+
+        it 'should raise a protocol error when message size exceeded 65536 bytes' do
+          allow(connection).to receive(:serial).and_return(12312312)
+          allow(subject).to receive(:update_connection_recovery_info)
+          allow(subject).to receive_message_chain(:logger, :debug)
+          allow(subject).to receive_message_chain(:logger, :warn)
+          expect(subject).to receive_message_chain(:logger, :fatal)
+
+          msgbus.publish :protocol_message, protocol_message
+        end
+      end
+    end
   end
 end

--- a/spec/unit/rest/channel_spec.rb
+++ b/spec/unit/rest/channel_spec.rb
@@ -14,6 +14,10 @@ describe Ably::Rest::Channel do
 
   subject { Ably::Rest::Channel.new(client, channel_name) }
 
+  it 'should return Ably::Rest::Channel::MAX_MESSAGE_SIZE equal 65536 (TO3l8)' do
+    expect(Ably::Rest::Channel::MAX_MESSAGE_SIZE).to eq(65536)
+  end
+
   describe '#initializer' do
     let(:channel_name) { random_str.encode(encoding) }
 
@@ -124,6 +128,12 @@ describe Ably::Rest::Channel do
 
       it 'raises an argument error' do
         expect { subject.publish(encoded_value, 'data') }.to raise_error ArgumentError, /must be a String/
+      end
+    end
+
+    context 'max message size exceeded' do
+      it 'should raise Ably::Exceptions::MaxMessageSizeExceeded' do
+        expect { subject.publish('x' * 65537, 'data') }.to raise_error Ably::Exceptions::MaxMessageSizeExceeded
       end
     end
   end


### PR DESCRIPTION
#247 

- Updated `Message` and `PresenceMessage` classes: added size
- Added `max_message_size` to `ConnectionDetails`
- Updated `ProtocolMessage` (message and presence actions): added `has_correct_message_size?` and `message_size`
- Updated `IncomingMessageDispatcher`.
- Added `MaxMessageSizeExceeded` exception
- Added `MAX_MESSAGE_SIZE` global variable
- Updated `Ably::Rest::Channel#publish`
- Updated `Ably::Realtime::Publisher#enqueue_messages_on_connection`
- Added rspec units, models, acceptance tests