### PR TITLE
TO3l9 Max frame size

### DIFF
--- a/lib/ably/exceptions.rb
+++ b/lib/ably/exceptions.rb
@@ -52,6 +52,9 @@ module Ably
       end
     end
 
+    # Maximum frame size exceeded TO3l9
+    class MaxFrameSizeExceeded < BaseAblyException; end
+
     # Maximum message size exceeded TO3l8
     class MaxMessageSizeExceeded < BaseAblyException; end
 

--- a/lib/ably/models/connection_details.rb
+++ b/lib/ably/models/connection_details.rb
@@ -39,6 +39,7 @@ module Ably::Models
         end
       end
       self.attributes[:max_message_size] ||= 65536
+      self.attributes[:max_frame_size] ||= 524288
       self.attributes.freeze
     end
 

--- a/lib/ably/rest/client.rb
+++ b/lib/ably/rest/client.rb
@@ -25,6 +25,8 @@ module Ably
       # Default Ably domain for REST
       DOMAIN = 'rest.ably.io'
 
+      MAX_FRAME_SIZE = 524288
+
       # Configuration for HTTP timeouts and HTTP request reattempts to fallback hosts
       HTTP_DEFAULTS = {
         open_timeout:       4,
@@ -363,6 +365,9 @@ module Ably
             send_request(method, path, params, headers: headers)
           end
         when :post, :patch, :put
+          if body.to_json.bytesize > MAX_FRAME_SIZE
+            raise Ably::Exceptions::MaxFrameSizeExceeded.new("Maximum frame size exceeded #{MAX_FRAME_SIZE} bytes.")
+          end
           path_with_params = Addressable::URI.new
           path_with_params.query_values = params || {}
           query = path_with_params.query

--- a/spec/acceptance/rest/client_spec.rb
+++ b/spec/acceptance/rest/client_spec.rb
@@ -1103,7 +1103,7 @@ describe Ably::Rest::Client do
       end
     end
 
-    context '#request (#RSC19*)' do
+    context '#request (#RSC19*, #TO3l9)' do
       let(:client_options) { default_options.merge(key: api_key) }
       let(:device_id) { random_str }
       let(:endpoint) { client.endpoint }
@@ -1158,6 +1158,12 @@ describe Ably::Rest::Client do
 
           expect(response).to be_success
         end
+
+        it 'raises an exception once body size in bytes exceeded' do
+          expect {
+            client.request(:post, endpoint, {}, { content: 'x' * Ably::Rest::Client::MAX_FRAME_SIZE })
+          }.to raise_error(Ably::Exceptions::MaxFrameSizeExceeded)
+        end
       end
 
       context 'delete', :webmock do
@@ -1187,6 +1193,12 @@ describe Ably::Rest::Client do
 
           expect(response).to be_success
         end
+
+        it 'raises an exception once body size in bytes exceeded' do
+          expect {
+            client.request(:patch, endpoint, {}, { content: 'x' * Ably::Rest::Client::MAX_FRAME_SIZE })
+          }.to raise_error(Ably::Exceptions::MaxFrameSizeExceeded)
+        end
       end
 
       context 'put', :webmock do
@@ -1209,6 +1221,12 @@ describe Ably::Rest::Client do
           response = client.request(:put, "/push/deviceRegistrations/#{device_id}", {}, body_params)
 
           expect(response).to be_success
+        end
+
+        it 'raises an exception once body size in bytes exceeded' do
+          expect {
+            client.request(:put, endpoint, {}, { content: 'x' * Ably::Rest::Client::MAX_FRAME_SIZE })
+          }.to raise_error(Ably::Exceptions::MaxFrameSizeExceeded)
         end
       end
     end

--- a/spec/shared/model_behaviour.rb
+++ b/spec/shared/model_behaviour.rb
@@ -19,7 +19,7 @@ shared_examples 'a model' do |shared_options = {}|
     end
 
     context '#attributes', :api_private do
-      let(:model_options) { { action: 5, max_message_size: 65536 } }
+      let(:model_options) { { action: 5, max_message_size: 65536, max_frame_size: 524288 } }
 
       it 'provides access to #attributes' do
         expect(model.attributes).to eq(model_options)


### PR DESCRIPTION
Resolves #245 

Checking body size in the `Ably::Rest::Client#request` (for `:post`, `:patch`, `:put` methods only).