### PR TITLE
Ruby 3.0 support

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,7 +10,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        ruby: [ '2.5', '2.6', '2.7' ]
+        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
         protocol: [ 'json', 'msgpack' ]
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Ruby client library for [ably.com](https://ably.com), the realtime messaging s
 
 ## Supported platforms
 
-This SDK supports Ruby 1.9.3+.
+This SDK supports Ruby 1.9.3+. For eventmachine and Ruby 3.0 note please visit [Ruby 3.0 support](#ruby-30-support) section.
 
 As of v1.1.5 this library requires `libcurl` as a system dependency. On most systems this is already installed but in rare cases where it isn't (for example debian-slim Docker images such as ruby-slim) you will need to install it yourself. On debian you can install it with the command `sudo apt-get install libcurl4`.
 

--- a/README.md
+++ b/README.md
@@ -287,6 +287,16 @@ stats_page.next # retrieves the next page => #<Ably::Models::PaginatedResult ...
 client.time #=> 2013-12-12 14:23:34 +0000
 ```
 
+## Ruby 3.0 support
+
+If you cannot install ably realtime gem because of eventmachine openssl problems, please try to set your `openssl-dir`, i.e.:
+
+```ruby
+gem install eventmachine -- --with-openssl-dir=/usr/local/opt/openssl@1.1
+```
+
+More about eventmachine and ruby 3.0 support here https://github.com/eventmachine/eventmachine/issues/932
+
 ## Dependencies
 
 If you only need to use the REST features of this library and do not want EventMachine as a dependency, then you should consider using the [Ably Ruby REST gem](https://rubygems.org/gems/ably-rest).

--- a/ably.gemspec
+++ b/ably.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'redcarpet', '~> 3.3'
-  spec.add_development_dependency 'rspec', '~> 3.10.0' # version lock, see config.around(:example, :event_machine) in event_machine_helper.rb
+  spec.add_development_dependency 'rspec', '~> 3.3.0' # version lock, see config.around(:example, :event_machine) in event_machine_helper.rb
   spec.add_development_dependency 'rspec-retry', '~> 0.6'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'rspec-instafail', '~> 1.0'

--- a/ably.gemspec
+++ b/ably.gemspec
@@ -33,9 +33,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'msgpack', '>= 1.3.0'
   spec.add_runtime_dependency 'addressable', '>= 2.0.0'
 
-  spec.add_development_dependency 'rake', '~> 11.3'
+  spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'redcarpet', '~> 3.3'
-  spec.add_development_dependency 'rspec', '~> 3.3.0' # version lock, see config.around(:example, :event_machine) in event_machine_helper.rb
+  spec.add_development_dependency 'rspec', '~> 3.10.0' # version lock, see config.around(:example, :event_machine) in event_machine_helper.rb
   spec.add_development_dependency 'rspec-retry', '~> 0.6'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'rspec-instafail', '~> 1.0'
@@ -48,14 +48,14 @@ Gem::Specification.new do |spec|
   else
     spec.add_development_dependency 'webmock', '~> 3.11'
     spec.add_development_dependency 'coveralls'
-    spec.add_development_dependency 'parallel_tests', '~> 2.22'
+    spec.add_development_dependency 'parallel_tests', '~> 3.7'
     if !RUBY_VERSION.match(/^2\.[0123]/)
-      spec.add_development_dependency 'pry'
-      spec.add_development_dependency 'pry-byebug'
+      spec.add_development_dependency 'pry', '~> 0.14.1'
+      spec.add_development_dependency 'pry-byebug', '~> 3.8.0'
     end
   end
 
   if RUBY_VERSION.match(/^3\./)
-    spec.add_development_dependency 'webrick'
+    spec.add_development_dependency 'webrick', '~> 1.7.0'
   end
 end

--- a/ably.gemspec
+++ b/ably.gemspec
@@ -54,4 +54,8 @@ Gem::Specification.new do |spec|
       spec.add_development_dependency 'pry-byebug'
     end
   end
+
+  if RUBY_VERSION.match(/^3\./)
+    spec.add_development_dependency 'webrick'
+  end
 end

--- a/spec/acceptance/realtime/auth_spec.rb
+++ b/spec/acceptance/realtime/auth_spec.rb
@@ -1237,7 +1237,7 @@ describe Ably::Realtime::Auth, :event_machine do
         let(:basic_capability) { JSON.dump(channel_name => ['subscribe'], channel_with_publish_permissions => ['publish']) }
         let(:auth_callback) do
           lambda do |token_params|
-            Faraday.get("#{auth_url}?keyName=#{key_name}&keySecret=#{key_secret}&capability=#{Addressable::URI.encode(basic_capability)}").body
+            Faraday.get("#{auth_url}?keyName=#{key_name}&keySecret=#{key_secret}&capability=#{URI::Parser.new.escape(basic_capability)}").body
           end
         end
         let(:client_options) { default_options.merge(auth_callback: auth_callback, log_level: :error) }

--- a/spec/acceptance/realtime/auth_spec.rb
+++ b/spec/acceptance/realtime/auth_spec.rb
@@ -1237,7 +1237,7 @@ describe Ably::Realtime::Auth, :event_machine do
         let(:basic_capability) { JSON.dump(channel_name => ['subscribe'], channel_with_publish_permissions => ['publish']) }
         let(:auth_callback) do
           lambda do |token_params|
-            Faraday.get("#{auth_url}?keyName=#{key_name}&keySecret=#{key_secret}&capability=#{URI.escape(basic_capability)}").body
+            Faraday.get("#{auth_url}?keyName=#{key_name}&keySecret=#{key_secret}&capability=#{Addressable::URI.encode(basic_capability)}").body
           end
         end
         let(:client_options) { default_options.merge(auth_callback: auth_callback, log_level: :error) }


### PR DESCRIPTION
Resolves #220

Added ruby 3.0 to the github workflow action matrix
Updated README.md (Ruby 3.0 support and eventmachine `openssl-dir` issue)
Added webrick development requirement (required by Rest client development)


Similar pull request for Ably Rest gem https://github.com/ably/ably-ruby-rest/pull/18