### PR TITLE
New Coveralls Github Actions implementation

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,6 +13,9 @@ jobs:
         ruby: [ '2.5', '2.6', '2.7' ]
         protocol: [ 'json', 'msgpack' ]
     steps:
+      - uses: coverallsapp/github-action@1.1.3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,3 +28,14 @@ jobs:
       - uses: coverallsapp/github-action@1.1.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          flag-name: run-ruby_${{ matrix.ruby }}-${{ matrix.protocol }}_protocol
+          parallel: true
+  finish:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@1.1.3
+        with:
+          github-token: ${{ secrets.github_token }}
+          parallel-finished: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,9 +13,6 @@ jobs:
         ruby: [ '2.5', '2.6', '2.7' ]
         protocol: [ 'json', 'msgpack' ]
     steps:
-      - uses: coverallsapp/github-action@1.1.3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
@@ -28,3 +25,6 @@ jobs:
           PARALLEL_TEST_PROCESSORS: 2
           PROTOCOL: ${{ matrix.protocol }}
         run: ./spec/run_parallel_tests
+      - uses: coverallsapp/github-action@1.1.3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/ably.gemspec
+++ b/ably.gemspec
@@ -47,7 +47,8 @@ Gem::Specification.new do |spec|
     spec.add_development_dependency 'parallel_tests', '~> 2.9.0'
   else
     spec.add_development_dependency 'webmock', '~> 3.11'
-    spec.add_development_dependency 'coveralls'
+    spec.add_development_dependency 'simplecov', '~> 0.21.2'
+    spec.add_development_dependency 'simplecov-lcov', '~> 0.8.0'
     spec.add_development_dependency 'parallel_tests', '~> 2.22'
     if !RUBY_VERSION.match(/^2\.[0123]/)
       spec.add_development_dependency 'pry'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,8 +5,17 @@ def console(message)
 end
 
 unless RUBY_VERSION.match(/^1\./)
-  require 'coveralls'
-  Coveralls.wear!
+  require 'simplecov'
+
+  SimpleCov.start do
+    require 'simplecov-lcov'
+    SimpleCov::Formatter::LcovFormatter.config do |c|
+      c.report_with_single_file = true
+      c.single_report_path = 'coverage/lcov.info'
+    end
+    formatter SimpleCov::Formatter::LcovFormatter
+    add_filter %w[vendor]
+  end
 end
 
 require 'webmock/rspec'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ unless RUBY_VERSION.match(/^1\./)
       c.single_report_path = 'coverage/lcov.info'
     end
     formatter SimpleCov::Formatter::LcovFormatter
-    add_filter %w[vendor]
+    add_filter %w[vendor spec]
   end
 end
 


### PR DESCRIPTION
Added `coverallsapp/github-action@1.1.3` to `check.yml`
Removed coveralls gem. Updated `ably.gemspec`
Added `simplecov-lcov`.
Set up parallel job and flag for uploading coverage data.

Docs: https://github.com/marketplace/actions/coveralls-github-action
