### PR TITLE
Enabled TLS hostname validation CVE-2020-13482

### DIFF
--- a/lib/ably/realtime/connection.rb
+++ b/lib/ably/realtime/connection.rb
@@ -295,7 +295,7 @@ module Ably
       def internet_up?
         url = "http#{'s' if client.use_tls?}:#{Ably::INTERNET_CHECK.fetch(:url)}"
         EventMachine::DefaultDeferrable.new.tap do |deferrable|
-          EventMachine::HttpRequest.new(url).get.tap do |http|
+          EventMachine::HttpRequest.new(url, tls: { verify_peer: true }).get.tap do |http|
             http.errback do
               yield false if block_given?
               deferrable.fail Ably::Exceptions::ConnectionFailed.new("Unable to connect to #{url}", nil, Ably::Exceptions::Codes::CONNECTION_FAILED)

--- a/spec/acceptance/realtime/connection_spec.rb
+++ b/spec/acceptance/realtime/connection_spec.rb
@@ -1454,7 +1454,7 @@ describe Ably::Realtime::Connection, :event_machine do
             let(:client_options) { default_options.merge(tls: true) }
 
             it 'uses TLS for the Internet check to https://internet-up.ably-realtime.com/is-the-internet-up.txt' do
-              expect(EventMachine::HttpRequest).to receive(:new).with('https://internet-up.ably-realtime.com/is-the-internet-up.txt').and_return(http_request)
+              expect(EventMachine::HttpRequest).to receive(:new).with('https://internet-up.ably-realtime.com/is-the-internet-up.txt', { tls: { verify_peer: true } }).and_return(http_request)
               connection.internet_up?
               stop_reactor
             end
@@ -1464,7 +1464,7 @@ describe Ably::Realtime::Connection, :event_machine do
             let(:client_options) { default_options.merge(tls: false, use_token_auth: true) }
 
             it 'uses TLS for the Internet check to http://internet-up.ably-realtime.com/is-the-internet-up.txt' do
-              expect(EventMachine::HttpRequest).to receive(:new).with('http://internet-up.ably-realtime.com/is-the-internet-up.txt').and_return(http_request)
+              expect(EventMachine::HttpRequest).to receive(:new).with('http://internet-up.ably-realtime.com/is-the-internet-up.txt', { tls: { verify_peer: true } }).and_return(http_request)
               connection.internet_up?
               stop_reactor
             end
@@ -1478,7 +1478,7 @@ describe Ably::Realtime::Connection, :event_machine do
             let(:client_options) { default_options.merge(tls: true) }
 
             it 'checks the Internet up URL over TLS' do
-              expect(EventMachine::HttpRequest).to receive(:new).with("https:#{Ably::INTERNET_CHECK.fetch(:url)}").and_return(double('request', get: EventMachine::DefaultDeferrable.new))
+              expect(EventMachine::HttpRequest).to receive(:new).with("https:#{Ably::INTERNET_CHECK.fetch(:url)}", { tls: { verify_peer: true } }).and_return(double('request', get: EventMachine::DefaultDeferrable.new))
               connection.internet_up?
               stop_reactor
             end
@@ -1488,7 +1488,7 @@ describe Ably::Realtime::Connection, :event_machine do
             let(:client_options) { default_options.merge(tls: false, use_token_auth: true) }
 
             it 'checks the Internet up URL over TLS' do
-              expect(EventMachine::HttpRequest).to receive(:new).with("http:#{Ably::INTERNET_CHECK.fetch(:url)}").and_return(double('request', get: EventMachine::DefaultDeferrable.new))
+              expect(EventMachine::HttpRequest).to receive(:new).with("http:#{Ably::INTERNET_CHECK.fetch(:url)}", { tls: { verify_peer: true } }).and_return(double('request', get: EventMachine::DefaultDeferrable.new))
               connection.internet_up?
               stop_reactor
             end


### PR DESCRIPTION
TLS hostname validation CVE-2020-13482
https://github.com/igrigorik/em-http-request/issues/339 for details.

Added `tls: { verify_peer: true }` parameter to `EventMachine::HttpRequest.new()`