### PR TITLE
Using xit() instead of pending() inside it() {} block

### DIFF
--- a/spec/acceptance/realtime/connection_failures_spec.rb
+++ b/spec/acceptance/realtime/connection_failures_spec.rb
@@ -1320,8 +1320,9 @@ describe Ably::Realtime::Connection, 'failures', :event_machine do
             end)
           end
 
-          it 'triggers a re-authentication and then resumes the connection' do
-            pending "After sandbox env update connection isn't found and a new connection is created. Spec fails"
+          xit 'triggers a re-authentication and then resumes the connection' do
+            # [PENDING] After sandbox env update connection isn't found and a new connection is created. Spec fails
+            #
             connection.once(:connected) do
               connection_id = connection.id
 


### PR DESCRIPTION
`pending` inside the `it() { ... }` block will still execute callbacks, for example `before` callback.

Marked one spec with `xit()` and commented `pending()`