### PR TITLE
Remove deprecated ProtocolMessage#connection_key TR4e

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -3299,8 +3299,6 @@ _(see [spec/unit/models/protocol_message_spec.rb](./spec/unit/models/protocol_me
         * [retrieves attribute :channel_serial](./spec/shared/model_behaviour.rb#L15)
       * #connection_id
         * [retrieves attribute :connection_id](./spec/shared/model_behaviour.rb#L15)
-      * #connection_key
-        * [retrieves attribute :connection_key](./spec/shared/model_behaviour.rb#L15)
     * #==
       * [is true when attributes are the same](./spec/shared/model_behaviour.rb#L41)
       * [is false when attributes are not the same](./spec/shared/model_behaviour.rb#L46)
@@ -3386,11 +3384,6 @@ _(see [spec/unit/models/protocol_message_spec.rb](./spec/unit/models/protocol_me
         * [contains the attributes from the JSON auth details](./spec/unit/models/protocol_message_spec.rb#L358)
       * without a JSON value
         * [contains an empty AuthDetails object](./spec/unit/models/protocol_message_spec.rb#L366)
-    * #connection_key (#TR4e)
-      * existing only in #connection_details.connection_key
-        * [is returned](./spec/unit/models/protocol_message_spec.rb#L377)
-      * existing in both #connection_key and #connection_details.connection_key
-        * [returns #connection_details.connection_key as #connection_key will be deprecated > 0.8](./spec/unit/models/protocol_message_spec.rb#L385)
 
 ### Ably::Models::PushChannelSubscription
 _(see [spec/unit/models/push_channel_subscription_spec.rb](./spec/unit/models/push_channel_subscription_spec.rb))_

--- a/lib/ably/models/protocol_message.rb
+++ b/lib/ably/models/protocol_message.rb
@@ -19,8 +19,6 @@ module Ably::Models
   # @!attribute [r] channel_serial
   #   @return [String] Contains a serial number for a message on the current channel
   # @!attribute [r] connection_id
-  #   @return [String] Contains a string public identifier for the connection
-  # @!attribute [r] connection_key
   #   @return [String] Contains a string private connection key used to recover this connection
   # @!attribute [r] connection_serial
   #   @return [Bignum] Contains a serial number for a message sent from the server to the client
@@ -96,12 +94,6 @@ module Ably::Models
       define_method attribute do
         attributes[attribute.to_sym]
       end
-    end
-
-    def connection_key
-      # connection_key in connection details takes precedence over connection_key on the ProtocolMessage
-      # connection_key in the ProtocolMessage will be deprecated in future protocol versions > 0.8
-      connection_details.connection_key || attributes[:connection_key]
     end
 
     def id!

--- a/lib/ably/realtime/connection/connection_manager.rb
+++ b/lib/ably/realtime/connection/connection_manager.rb
@@ -117,17 +117,17 @@ module Ably::Realtime
             EventMachine.next_tick { connection.trigger_resumed }
             resend_pending_message_ack_queue
           else
-            logger.debug { "ConnectionManager: Connection was not resumed, old connection ID #{connection.id} has been updated with new connection ID #{protocol_message.connection_id} and key #{protocol_message.connection_key}" }
+            logger.debug { "ConnectionManager: Connection was not resumed, old connection ID #{connection.id} has been updated with new connection ID #{protocol_message.connection_id} and key #{protocol_message.connection_details.connection_key}" }
             nack_messages_on_all_channels protocol_message.error
             force_reattach_on_channels protocol_message.error
           end
         else
-          logger.debug { "ConnectionManager: New connection created with ID #{protocol_message.connection_id} and key #{protocol_message.connection_key}" }
+          logger.debug { "ConnectionManager: New connection created with ID #{protocol_message.connection_id} and key #{protocol_message.connection_details.connection_key}" }
         end
 
         reattach_suspended_channels protocol_message.error
 
-        connection.configure_new protocol_message.connection_id, protocol_message.connection_key, protocol_message.connection_serial
+        connection.configure_new protocol_message.connection_id, protocol_message.connection_details.connection_key, protocol_message.connection_serial
       end
 
       # When connection is CONNECTED and receives an update
@@ -139,7 +139,7 @@ module Ably::Realtime
         # Update the connection details and any associated defaults
         connection.set_connection_details protocol_message.connection_details
 
-        connection.configure_new protocol_message.connection_id, protocol_message.connection_key, protocol_message.connection_serial
+        connection.configure_new protocol_message.connection_id, protocol_message.connection_details.connection_key, protocol_message.connection_serial
 
         state_change = Ably::Models::ConnectionStateChange.new(
           current: connection.state,

--- a/spec/unit/models/protocol_message_spec.rb
+++ b/spec/unit/models/protocol_message_spec.rb
@@ -10,9 +10,9 @@ describe Ably::Models::ProtocolMessage do
     subject.new({ action: 1 }.merge(options))
   end
 
-  # TR4n, TR4b, TR4c, TR4d, TR4e
+  # TR4n, TR4b, TR4c, TR4d
   it_behaves_like 'a model',
-    with_simple_attributes: %w(id channel channel_serial connection_id connection_key),
+    with_simple_attributes: %w(id channel channel_serial connection_id),
     base_model_options: { action: 1 } do
 
     let(:model_args) { [] }
@@ -414,24 +414,6 @@ describe Ably::Models::ProtocolMessage do
         it 'contains an empty AuthDetails object' do
           expect(auth).to be_a(Ably::Models::AuthDetails)
           expect(auth.access_token).to eql(nil)
-        end
-      end
-    end
-
-    context '#connection_key (#TR4e)' do
-      context 'existing only in #connection_details.connection_key' do
-        let(:protocol_message) { new_protocol_message(connectionDetails: { connectionKey: 'key' }) }
-
-        it 'is returned' do
-          expect(protocol_message.connection_key).to eql('key')
-        end
-      end
-
-      context 'existing in both #connection_key and #connection_details.connection_key' do
-        let(:protocol_message) { new_protocol_message(connectionKey: 'deprecated', connectionDetails: { connectionKey: 'key' }) }
-
-        it 'returns #connection_details.connection_key as #connection_key will be deprecated > 0.8' do
-          expect(protocol_message.connection_key).to eql('key')
         end
       end
     end


### PR DESCRIPTION
As part of https://github.com/ably/ably-ruby/issues/244