### PR TITLE
Change behavior when reconnecting from failed state (RTN11d)

### DIFF
--- a/lib/ably/realtime/channel/channel_state_machine.rb
+++ b/lib/ably/realtime/channel/channel_state_machine.rb
@@ -26,10 +26,14 @@ module Ably::Realtime
       transition :from => :detaching,    :to => [:detached, :attaching, :attached, :failed, :suspended]
       transition :from => :detached,     :to => [:attaching, :attached, :failed]
       transition :from => :suspended,    :to => [:attaching, :attached, :detached, :failed]
-      transition :from => :failed,       :to => [:attaching]
+      transition :from => :failed,       :to => [:attaching, :initialized]
 
       after_transition do |channel, transition|
         channel.synchronize_state_with_statemachine
+      end
+
+      after_transition(to: [:initialized]) do |channel|
+        channel.clear_error_reason
       end
 
       after_transition(to: [:attaching]) do |channel|

--- a/lib/ably/realtime/connection/connection_manager.rb
+++ b/lib/ably/realtime/connection/connection_manager.rb
@@ -319,6 +319,15 @@ module Ably::Realtime
         end
       end
 
+      # @api private
+      def reintialize_failed_chanels
+        channels.select do |channel|
+          channel.failed?
+        end.each do |channel|
+          channel.transition_state_machine :initialized
+        end
+      end
+
       # When continuity on a connection is lost all messages
       # whether queued or awaiting an ACK must be NACK'd as we now have a new connection
       def nack_messages_on_all_channels(error)

--- a/lib/ably/realtime/connection/connection_state_machine.rb
+++ b/lib/ably/realtime/connection/connection_state_machine.rb
@@ -36,6 +36,10 @@ module Ably::Realtime
         connection.manager.setup_transport
       end
 
+      after_transition(to: [:connecting], from: [:failed]) do |connection|
+        connection.manager.reintialize_failed_chanels
+      end
+
       after_transition(to: [:connecting], from: [:disconnected, :suspended]) do |connection|
         connection.manager.reconnect_transport
       end


### PR DESCRIPTION
Connecting from failed state clears error reasons and reinitializes channels

As part of https://github.com/ably/ably-ruby/issues/244