### PR TITLE
Added Channel#set_options and Channel#options= aliases

### DIFF
--- a/lib/ably/realtime/channel.rb
+++ b/lib/ably/realtime/channel.rb
@@ -323,6 +323,8 @@ module Ably
       def update_options(channel_options)
         @options = channel_options.clone.freeze
       end
+      alias set_options update_options # (RSL7)
+      alias options= update_options
 
       # Used by {Ably::Modules::StateEmitter} to debug state changes
       # @api private

--- a/lib/ably/rest/channel.rb
+++ b/lib/ably/rest/channel.rb
@@ -168,6 +168,8 @@ module Ably
       def update_options(channel_options)
         @options = channel_options.clone.freeze
       end
+      alias set_options update_options # (RSL7)
+      alias options= update_options
 
       private
       def base_path


### PR DESCRIPTION
Resolves #271 

`Channel#set_options` (RSL7) was implemented as `Channel#update_options`.
Added aliases: `Channel#options=` and `Channel#set_options`