### PR TITLE
Add support for RSA4b, b1, c, RSA16 (Authentication)

### DIFF
--- a/lib/ably/auth.rb
+++ b/lib/ably/auth.rb
@@ -510,11 +510,11 @@ module Ably
     end
 
     def authorize_when_necessary
-      if current_token_details && !current_token_details.expired?
+      if current_token_details && !current_token_details.expired?(from: current_time)
         return current_token_details
-      else
-        authorize
       end
+
+      authorize
     end
 
     # Returns the current device clock time unless the

--- a/lib/ably/models/token_details.rb
+++ b/lib/ably/models/token_details.rb
@@ -95,10 +95,15 @@ module Ably::Models
     # Returns true if token is expired or about to expire
     # For tokens that have not got an explicit expires attribute expired? will always return true
     #
+    # @param attributes [Hash]
+    # @option attributes [Time] :from   Sets a current time from which token expires
+    #
     # @return [Boolean]
-    def expired?
+    def expired?(attributes = {})
       return false if !expires
-      expires < Time.now + TOKEN_EXPIRY_BUFFER
+
+      from = attributes[:from] || Time.now
+      expires < from + TOKEN_EXPIRY_BUFFER
     end
 
     # True if the TokenDetails was created from an opaque string i.e. no metadata exists for this token

--- a/spec/acceptance/rest/auth_spec.rb
+++ b/spec/acceptance/rest/auth_spec.rb
@@ -1172,24 +1172,15 @@ describe Ably::Auth do
         context 'for the next 2 hours' do
           let(:local_time) { Time.now - 2 * 60 * 60 }
 
-          before do
-            @now = Time.now
-            allow(Time).to receive(:now).and_return(local_time)
-          end
+          before { allow(Time).to receive(:now).and_return(local_time) }
 
-          it 'saves a round-trip request (#RSA4b1)' do
-            expect(auth.current_token_details).to be_nil
-            channel.publish 'event'
-            expect(auth.current_token_details).not_to be_nil
-
-            token = auth.current_token_details
-
-            sleep 2.5
-            channel.publish 'event'
-            expect(auth.current_token_details).to eql(token)
+          it 'should not request for the new token (#RSA4b1)' do
+            expect { channel.publish 'event' }.to change { auth.current_token_details }
+            expect do
+              expect { channel.publish 'event' }.not_to change { auth.current_token_details }
+            end.not_to change { auth.current_token_details.expires }
           end
         end
-
       end
 
       context 'when :client_id is provided in a token' do

--- a/spec/unit/models/token_details_spec.rb
+++ b/spec/unit/models/token_details_spec.rb
@@ -80,6 +80,20 @@ describe Ably::Models::TokenDetails do
           expect(subject.expired?).to eql(false)
         end
       end
+
+      context 'with :from attribute' do
+        subject { Ably::Models::TokenDetails.new(expires: expire_time) }
+
+        let(:server_offset_time) { 2 * 60 * 60 } # 2 hours
+
+        it 'is false' do
+          expect(subject.expired?(from: (Time.now - server_offset_time))).to eql(false)
+        end
+
+        it 'is true' do
+          expect(subject.expired?(from: Time.now)).to eql(true)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Resolves #268  #281 

- [x] Using current time when checking token expiration (updated TokenDetails#expired? method by adding attributes and `from` option) RSA4b, RSA4b1
- [x] RSA16 is already implemented and tested as `current_token_details`