### PR TITLE
RSL1a, RSL1b

### DIFF
--- a/lib/ably/modules/conversions.rb
+++ b/lib/ably/modules/conversions.rb
@@ -121,10 +121,11 @@ module Ably::Modules
     # @return [Array<Ably::Models::Message>]
     #
     def build_messages(name, data = nil, attributes = {})
-      if name.kind_of?(Enumerable)
-        return name.map { |item| Ably::Models::Message(ensure_supported_name_and_payload(item, data, attributes)) }
+      return [Ably::Models::Message(ensure_supported_name_and_payload(nil, data, attributes))] if name.nil?
+
+      Array(name).map do |item|
+        Ably::Models::Message(ensure_supported_name_and_payload(item, data, attributes))
       end
-      [Ably::Models::Message(ensure_supported_name_and_payload(name, data, attributes))]
     end
 
     # Ensures if the first argument (name) is a String, Hash or Ably::Models::Message object,

--- a/lib/ably/modules/conversions.rb
+++ b/lib/ably/modules/conversions.rb
@@ -116,37 +116,37 @@ module Ably::Modules
       raise Ably::Exceptions::UnsupportedDataType.new('Invalid data payload', 400, Ably::Exceptions::Codes::INVALID_MESSAGE_DATA_OR_ENCODING)
     end
 
-    # It converts the name, data, attributes into the array of Message objects
+    # Converts the name, data, attributes into the array of Message objects
     #
     # @return [Array<Ably::Models::Message>]
     #
     def build_messages(name, data = nil, attributes = {})
       if name.kind_of?(Enumerable)
-        return name.map { |item| Ably::Models::Message(ensure_supported_name_and_payload(item, data, attributes).dup) }
+        return name.map { |item| Ably::Models::Message(ensure_supported_name_and_payload(item, data, attributes)) }
       end
-      [Ably::Models::Message(ensure_supported_name_and_payload(name, data, attributes).dup)]
+      [Ably::Models::Message(ensure_supported_name_and_payload(name, data, attributes))]
     end
 
     # Ensures if the first argument (name) is a String, Hash or Ably::Models::Message object,
     # second argument (data) should be a String, Hash, Array or nil (see ensure_supported_payload() method).
     #
-    # @return [Hash]        It contains :name, :data and other attributes
+    # @return [Hash]        Contains :name, :data and other attributes
     #
     # (RSL1a, RSL1b)
     #
-    def ensure_supported_name_and_payload(name, _data = nil, attributes = {})
-      return name.attributes if name.kind_of?(Ably::Models::Message)
+    def ensure_supported_name_and_payload(name, data = nil, attributes = {})
+      return name.attributes.dup if name.kind_of?(Ably::Models::Message)
 
-      data = _data
+      payload = data
       if (hash = name).kind_of?(Hash)
-        name, data = hash[:name], (hash[:data] || _data)
+        name, payload = hash[:name], (hash[:data] || payload)
         attributes.merge!(hash)
       end
 
       name = ensure_utf_8(:name, name, allow_nil: true)
-      ensure_supported_payload data
+      ensure_supported_payload payload
 
-      attributes.merge({ name: name, data: data })
+      attributes.merge({ name: name, data: payload })
     end
   end
 end

--- a/spec/acceptance/rest/message_spec.rb
+++ b/spec/acceptance/rest/message_spec.rb
@@ -24,6 +24,57 @@ describe Ably::Rest::Channel, 'messages' do
       end
     end
 
+    context 'a single Message object (#RSL1a)' do
+      let(:name) { random_str }
+      let(:data) { random_str }
+      let(:message) { Ably::Models::Message.new(name: name, data: data) }
+
+      it 'publishes the message' do
+        channel.publish(message)
+        expect(channel.history.items.length).to eql(1)
+        message = channel.history.items.first
+        expect(message.name).to eq(name)
+        expect(message.data).to eq(data)
+      end
+    end
+
+    context 'an array of Message objects (#RSL1a)' do
+      let(:data) { random_str }
+      let(:message1) { Ably::Models::Message.new(name: random_str, data: data) }
+      let(:message2) { Ably::Models::Message.new(name: random_str, data: data) }
+      let(:message3) { Ably::Models::Message.new(name: random_str, data: data) }
+
+      it 'publishes three messages' do
+        channel.publish([message1, message2, message3])
+        expect(channel.history.items.length).to eql(3)
+      end
+    end
+
+    context 'an array of hashes (#RSL1a)' do
+      let(:data) { random_str }
+      let(:message1) { { name: random_str, data: data } }
+      let(:message2) { { name: random_str, data: data } }
+      let(:message3) { { name: random_str, data: data } }
+
+      it 'publishes three messages' do
+        channel.publish([message1, message2, message3])
+        expect(channel.history.items.length).to eql(3)
+      end
+    end
+
+    context 'a name with data payload (#RSL1a, #RSL1b)' do
+      let(:name) { random_str }
+      let(:data) { random_str }
+
+      it 'publishes the message' do
+        channel.publish(name, data)
+        expect(channel.history.items.length).to eql(1)
+        message = channel.history.items.first
+        expect(message.name).to eq(name)
+        expect(message.data).to eq(data)
+      end
+    end
+
     context 'with supported data payload content type' do
       context 'JSON Object (Hash)' do
         let(:data) { { 'Hash' => 'true' } }


### PR DESCRIPTION
Resolves #283

- [x] Added tests RSL1a and RSL1b for both REST and Realtime clients
- [x] Ensure RSL1l, RSL1l1
- [x] Ensure RSL1h
- [x] Ensure RSL1k1, RSL1k2
- [x] Refactored `publish()` method in REST client
- [x] Refactored `publish()` method in Realtime client
- [x] Added `build_messages()` in `conversations.rb` and converting `name`, `data`, `attributes` to `Ably::Models::Message`

```ruby
# Publish a single message with (name, data) form (1)
channel.publish 'click', { x: 1, y: 2 }
      
# Publish a single message with single Hash form (2)
message = { name: 'click', data: { x: 1, y: 2 } }
channel.publish message
      
# Publish an array of message Hashes form (3)
messages = [
  { name: 'click', data: { x: 1, y: 2 } },
  { name: 'click', data: { x: 2, y: 3 } }
]
channel.publish messages
      
# Publish an array of Ably::Models::Message objects form (4)
messages = [
  Ably::Models::Message(name: 'click', data: { x: 1, y: 2 })
  Ably::Models::Message(name: 'click', data: { x: 2, y: 3 })
]
channel.publish messages
      
# Publish a single Ably::Models::Message object form (5)
message = Ably::Models::Message(name: 'click', data: { x: 1, y: 2 })
channel.publish message
      
```
