### PR TITLE
Allowing ConnectionDetails#max_message_size

### DIFF
--- a/lib/ably/models/connection_details.rb
+++ b/lib/ably/models/connection_details.rb
@@ -21,6 +21,12 @@ module Ably::Models
   class ConnectionDetails
     include Ably::Modules::ModelCommon
 
+    # Max message size
+    MAX_MESSAGE_SIZE = 65536 # See spec TO3l8
+
+    # Max frame size
+    MAX_FRAME_SIZE = 524288 # See spec TO3l9
+
     # @param attributes [Hash]
     # @option attributes [String]    :client_id             contains the client ID assigned to the connection
     # @option attributes [String]    :connection_key        the connection secret key string that is used to resume a connection and its state
@@ -38,8 +44,8 @@ module Ably::Models
           self.attributes[duration_field] = (self.attributes[duration_field].to_f / 1000).round
         end
       end
-      self.attributes[:max_message_size] ||= 65536
-      self.attributes[:max_frame_size] ||= 524288
+      self.attributes[:max_message_size] ||= MAX_MESSAGE_SIZE
+      self.attributes[:max_frame_size] ||= MAX_FRAME_SIZE
       self.attributes.freeze
     end
 

--- a/lib/ably/realtime/channel/publisher.rb
+++ b/lib/ably/realtime/channel/publisher.rb
@@ -22,8 +22,9 @@ module Ably::Realtime
           end
         end
 
-        if messages.sum(&:size) > Ably::Realtime::Connection::MAX_MESSAGE_SIZE
-          error = Ably::Exceptions::MaxMessageSizeExceeded.new("Message size exceeded #{Ably::Realtime::Connection::MAX_MESSAGE_SIZE} bytes.")
+        max_message_size = connection.details && connection.details.max_message_size || Ably::Models::ConnectionDetails::MAX_MESSAGE_SIZE
+        if messages.sum(&:size) > max_message_size
+          error = Ably::Exceptions::MaxMessageSizeExceeded.new("Message size exceeded #{max_message_size} bytes.")
           return Ably::Util::SafeDeferrable.new_and_fail_immediately(logger, error)
         end
 

--- a/lib/ably/realtime/connection.rb
+++ b/lib/ably/realtime/connection.rb
@@ -82,9 +82,6 @@ module Ably
       # Max number of messages to bundle in a single ProtocolMessage
       MAX_PROTOCOL_MESSAGE_BATCH_SIZE = 50
 
-      # Max message size
-      MAX_MESSAGE_SIZE = 65536 # See spec TO3l8
-
       # A unique public identifier for this connection, used to identify this member in presence events and messages
       # @return [String]
       attr_reader :id

--- a/lib/ably/rest/channel.rb
+++ b/lib/ably/rest/channel.rb
@@ -23,7 +23,6 @@ module Ably
       attr_reader :push
 
       IDEMPOTENT_LIBRARY_GENERATED_ID_LENGTH = 9 # See spec RSL1k1
-      MAX_MESSAGE_SIZE = 65536 # See spec TO3l8
 
       # Initialize a new Channel object
       #
@@ -88,8 +87,8 @@ module Ably
 
         messages.map! { |message| Ably::Models::Message(message.dup) }
 
-        if messages.sum(&:size) > Ably::Rest::Channel::MAX_MESSAGE_SIZE
-          raise Ably::Exceptions::MaxMessageSizeExceeded.new("Maximum message size exceeded #{Ably::Rest::Channel::MAX_MESSAGE_SIZE}.")
+        if messages.sum(&:size) > (max_message_size = client.max_message_size || Ably::Rest::Client::MAX_MESSAGE_SIZE)
+          raise Ably::Exceptions::MaxMessageSizeExceeded.new("Maximum message size exceeded #{max_message_size} bytes.")
         end
 
         payload = messages.map do |message|

--- a/spec/unit/realtime/channel_spec.rb
+++ b/spec/unit/realtime/channel_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 require 'shared/protocol_msgbus_behaviour'
 
 describe Ably::Realtime::Channel do
-  let(:client)       { double('client').as_null_object }
+  let(:client)       { Ably::Realtime::Client.new(token: 'valid') }
   let(:channel_name) { 'test' }
 
   subject do
@@ -71,6 +71,7 @@ describe Ably::Realtime::Channel do
     let(:message) { instance_double('Ably::Models::Message', client_id: nil, size: 0) }
 
     before do
+      allow(subject).to receive(:enqueue_messages_on_connection).and_return(message)
       allow(subject).to receive(:create_message).and_return(message)
       allow(subject).to receive(:attach).and_return(:true)
     end

--- a/spec/unit/rest/client_spec.rb
+++ b/spec/unit/rest/client_spec.rb
@@ -87,6 +87,33 @@ describe Ably::Rest::Client do
         end
       end
     end
+
+    context 'max_message_size' do
+      context 'is not present' do
+        let(:client_options) { { key: 'appid.keyuid:keysecret' } }
+
+        it 'should return default 65536 (#TO3l8)' do
+          expect(subject.max_message_size).to eq(Ably::Rest::Client::MAX_MESSAGE_SIZE)
+        end
+      end
+
+      context 'is nil' do
+        let(:client_options) { { key: 'appid.keyuid:keysecret', max_message_size: nil } }
+
+        it 'should return default 65536 (#TO3l8)' do
+          expect(Ably::Rest::Client::MAX_MESSAGE_SIZE).to eq(65536)
+          expect(subject.max_message_size).to eq(Ably::Rest::Client::MAX_MESSAGE_SIZE)
+        end
+      end
+
+      context 'is customized 131072 bytes' do
+        let(:client_options) { { key: 'appid.keyuid:keysecret', max_message_size: 131072 } }
+
+        it 'should return 131072' do
+          expect(subject.max_message_size).to eq(131072)
+        end
+      end
+    end
   end
 
   context 'request_id generation' do


### PR DESCRIPTION
Allowing `max_message_size` for Realtime client. Client gets `max_message_size` from current `connection.details`. `ConnectionDetails` attributes are populated when connection is in `CONNECTED` state.

Added `max_message_size` to `Ably::Rest::Client`.