### PR TITLE
Fix REST client idempotent_rest_publishing issue.

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -9,6 +9,8 @@ This release is all about channel options. Here is the full [changelog](https://
 
 * The `ChannelOptions` class now supports `:params`, `:modes` and `:cipher` as options. Previously only `:cipher` was available
 
+* The client `:idempotent_rest_publishing` option is `true` by default. Previously `:idempotent_rest_publishing` was `false` by default.
+
 ### Breaking Changes
 
 * Changing channel options with `Channels#get` is now deprecated in favor of explicit options change

--- a/lib/ably/rest/client.rb
+++ b/lib/ably/rest/client.rb
@@ -199,9 +199,12 @@ module Ably
         @custom_tls_port     = options.delete(:tls_port)
         @add_request_ids     = options.delete(:add_request_ids)
         @log_retries_as_info = options.delete(:log_retries_as_info)
-        @idempotent_rest_publishing = options.delete(:idempotent_rest_publishing) || Ably.major_minor_version_numeric > 1.1
         @max_message_size    = options.delete(:max_message_size) || MAX_MESSAGE_SIZE
         @max_frame_size      = options.delete(:max_frame_size) || MAX_FRAME_SIZE
+
+        if (@idempotent_rest_publishing = options.delete(:idempotent_rest_publishing)).nil?
+          @idempotent_rest_publishing = Ably::PROTOCOL_VERSION.to_f > 1.1
+        end
 
         if options[:fallback_hosts_use_default] && options[:fallback_hosts]
           raise ArgumentError, "fallback_hosts_use_default cannot be set to try when fallback_hosts is also provided"

--- a/spec/acceptance/rest/channel_spec.rb
+++ b/spec/acceptance/rest/channel_spec.rb
@@ -5,7 +5,7 @@ describe Ably::Rest::Channel do
   include Ably::Modules::Conversions
 
   vary_by_protocol do
-    let(:default_options) { { key: api_key, environment: environment, protocol: protocol, max_frame_size: max_frame_size, max_message_size: max_message_size } }
+    let(:default_options) { { key: api_key, environment: environment, protocol: protocol, max_frame_size: max_frame_size, max_message_size: max_message_size, idempotent_rest_publishing: false } }
     let(:client_options)  { default_options }
     let(:client) do
       Ably::Rest::Client.new(client_options)

--- a/spec/acceptance/rest/message_spec.rb
+++ b/spec/acceptance/rest/message_spec.rb
@@ -204,13 +204,20 @@ describe Ably::Rest::Channel, 'messages' do
         end
       end
 
-      specify 'idempotent publishing is disabled by default with 1.1 (#TO3n)' do
+      specify 'idempotent publishing is disabled by default with <= 1.1 (#TO3n)' do
+        stub_const 'Ably::PROTOCOL_VERSION', '1.0'
+        client = Ably::Rest::Client.new(key: api_key, protocol: protocol)
+        expect(client.idempotent_rest_publishing).to be_falsey
+        stub_const 'Ably::PROTOCOL_VERSION', '1.1'
         client = Ably::Rest::Client.new(key: api_key, protocol: protocol)
         expect(client.idempotent_rest_publishing).to be_falsey
       end
 
-      specify 'idempotent publishing is enabled by default with 1.2 (#TO3n)' do
-        stub_const 'Ably::VERSION', '1.2.0'
+      specify 'idempotent publishing is enabled by default with >= 1.2 (#TO3n)' do
+        stub_const 'Ably::PROTOCOL_VERSION', '1.2'
+        client = Ably::Rest::Client.new(key: api_key, protocol: protocol)
+        expect(client.idempotent_rest_publishing).to be_truthy
+        stub_const 'Ably::PROTOCOL_VERSION', '1.3'
         client = Ably::Rest::Client.new(key: api_key, protocol: protocol)
         expect(client.idempotent_rest_publishing).to be_truthy
       end


### PR DESCRIPTION
- [x] Fix idempotent_rest_publishing possible custom `false` value and change publish() related tests
- [x] Set idempotent_rest_publishing default false when Protocol Version is < 1.2 and change related tests
- [x] Add a notice to `UPDATING.md`

Related to https://ably-docs.herokuapp.com/client-lib-development-guide/features/#TO3n

Resolves #351