### PR TITLE
Fix urls in comments. Replace ably.io with ably.com

### DIFF
--- a/lib/ably/auth.rb
+++ b/lib/ably/auth.rb
@@ -5,9 +5,9 @@ require 'securerandom'
 require 'ably/rest/middleware/external_exceptions'
 
 module Ably
-  # Auth is responsible for authentication with {https://www.ably.io Ably} using basic or token authentication
+  # Auth is responsible for authentication with {https://www.ably.com Ably} using basic or token authentication
   #
-  # Find out more about Ably authentication at: https://www.ably.io/documentation/general/authentication/
+  # Find out more about Ably authentication at: https://www.ably.com/docs/general/authentication/
   #
   # @!attribute [r] client_id
   #   @return [String] The provided client ID, used for identifying this client for presence purposes
@@ -35,7 +35,7 @@ module Ably
 
     API_KEY_REGEX = /^[\w-]{2,}\.[\w-]{2,}:[\w-]{2,}$/
 
-    # Supported AuthOption keys, see https://www.ably.io/documentation/realtime/types#auth-options
+    # Supported AuthOption keys, see https://www.ably.com/docs/realtime/types#auth-options
     # TODO: Review client_id usage embedded incorrectly within AuthOptions.
     #       This is legacy code to configure a client with a client_id from the ClientOptions
     # TODO: Review inclusion of use_token_auth, ttl, token_params in auth options
@@ -277,7 +277,7 @@ module Ably
     #
     # @param [Hash] token_params the token params used in the token request
     # @option token_params [String]  :client_id     A client ID to associate with this token. The generated token may be used to authenticate as this +client_id+
-    # @option token_params [Integer] :ttl           validity time in seconds for the requested {Ably::Models::TokenDetails}.  Limits may apply, see {https://www.ably.io/documentation/other/authentication}
+    # @option token_params [Integer] :ttl           validity time in seconds for the requested {Ably::Models::TokenDetails}.  Limits may apply, see {https://www.ably.com/docs/general/authentication}
     # @option token_params [Hash]    :capability    canonicalised representation of the resource paths and associated operations
     # @option token_params [Time]    :timestamp     the time of the request
     # @option token_params [String]  :nonce         an unquoted, unescaped random string of at least 16 characters
@@ -285,7 +285,7 @@ module Ably
     # @param [Hash] auth_options the authentication options for the token request
     # @option auth_options [String]  :key           API key comprising the key name and key secret in a single string
     # @option auth_options [String]  :client_id     client ID identifying this connection to other clients (will use +client_id+ specified when library was instanced if provided)
-    # @option auth_options [Boolean] :query_time    when true will query the {https://www.ably.io Ably} system for the current time instead of using the local time
+    # @option auth_options [Boolean] :query_time    when true will query the {https://www.ably.com Ably} system for the current time instead of using the local time
     # @option auth_options [Hash]    :token_params  convenience to pass in +token_params+ within the +auth_options+ argument, especially useful when setting default token_params in the client constructor
     #
     # @return [Models::TokenRequest]

--- a/lib/ably/models/device_details.rb
+++ b/lib/ably/models/device_details.rb
@@ -27,7 +27,7 @@ module Ably::Models
   # @!attribute [r] form_factor
   #   @return [String] Device form factor such as phone, tablet, watch
   # @!attribute [r] client_id
-  #   @return [String] The authenticated client identifier for this device. See {https://www.ably.io/documentation/general/authentication#identified-clients auth documentation}.
+  #   @return [String] The authenticated client identifier for this device. See {https://www.ably.com/docs/general/authentication#identified-clients auth documentation}.
   # @!attribute [r] metadata
   #   @return [Hash] Arbitrary metadata that can be associated with a device
   # @!attribute [r] device_secret

--- a/lib/ably/models/protocol_message.rb
+++ b/lib/ably/models/protocol_message.rb
@@ -3,7 +3,7 @@ module Ably::Models
   # A ProtocolMessage always relates to a single channel only, but
   # can contain multiple individual Messages or PresenceMessages.
   # ProtocolMessages are serially numbered on a connection.
-  # See the {http://docs.ably.io/client-lib-development-guide/protocol/ Ably client library developer documentation}
+  # See the {http://ably.com/docs/client-lib-development-guide/protocol/ Ably client library developer documentation}
   # for further details on the members of a ProtocolMessage
   #
   # @!attribute [r] action
@@ -11,7 +11,7 @@ module Ably::Models
   # @!attribute [r] auth
   #   @return [Ably::Models::AuthDetails] Authentication details used to perform authentication upgrades over an existing transport
   # @!attribute [r] count
-  #   @return [Integer] The count field is used for ACK and NACK actions. See {http://docs.ably.io/client-lib-development-guide/protocol/#message-acknowledgement message acknowledgement protocol}
+  #   @return [Integer] The count field is used for ACK and NACK actions. See {http://ably.com/docs/client-lib-development-guide/protocol/#message-acknowledgement message acknowledgement protocol}
   # @!attribute [r] error
   #   @return [ErrorInfo] Contains error information
   # @!attribute [r] channel

--- a/lib/ably/models/token_request.rb
+++ b/lib/ably/models/token_request.rb
@@ -98,7 +98,7 @@ module Ably::Models
 
     # @!attribute [r] mac
     # @return [String]  the Message Authentication Code for this request. See the
-    #                   {https://www.ably.io/documentation Ably Authentication documentation} for more details.
+    #                   {https://www.ably.com/docs Ably Authentication documentation} for more details.
     def mac
       attributes.fetch(:mac) { raise Ably::Exceptions::InvalidTokenRequest, 'MAC is missing' }
     end

--- a/lib/ably/modules/ably.rb
+++ b/lib/ably/modules/ably.rb
@@ -6,7 +6,7 @@
 module Ably
   # Fallback hosts to use when a connection to rest/realtime.ably.io is not possible due to
   # network failures either at the client, between the client and Ably, within an Ably data center, or at the IO domain registrar
-  # see https://docs.ably.io/client-lib-development-guide/features/#RSC15a
+  # see https://ably.com/docs/client-lib-development-guide/features/#RSC15a
   #
   FALLBACK_DOMAIN = 'ably-realtime.com'.freeze
   FALLBACK_IDS = %w(a b c d e).freeze

--- a/lib/ably/realtime/auth.rb
+++ b/lib/ably/realtime/auth.rb
@@ -2,10 +2,10 @@ require 'ably/auth'
 
 module Ably
   module Realtime
-    # Auth is responsible for authentication with {https://www.ably.io Ably} using basic or token authentication
+    # Auth is responsible for authentication with {https://www.ably.com Ably} using basic or token authentication
     # This {Ably::Realtime::Auth Realtime::Auth} class wraps the {Ably::Auth Synchronous Ably::Auth} class in an EventMachine friendly way using Deferrables for all IO.  See {Ably::Auth Ably::Auth} for more information
     #
-    # Find out more about Ably authentication at: https://www.ably.io/documentation/general/authentication/
+    # Find out more about Ably authentication at: https://www.ably.com/docs/general/authentication/
     #
     # @!attribute [r] client_id
     #   (see Ably::Auth#client_id)

--- a/lib/ably/rest/client.rb
+++ b/lib/ably/rest/client.rb
@@ -147,7 +147,7 @@ module Ably
       # @option options [Symbol]                  :auth_method         (:get) HTTP method to use with +auth_url+, must be either +:get+ or +:post+
       # @option options [Proc]                    :auth_callback       when provided, the Proc will be called with the token params hash as the first argument, whenever a new token is required.
       #                                                                The Proc should return a token string, {Ably::Models::TokenDetails} or JSON equivalent, {Ably::Models::TokenRequest} or JSON equivalent
-      # @option options [Boolean]                 :query_time          when true will query the {https://www.ably.io Ably} system for the current time instead of using the local time
+      # @option options [Boolean]                 :query_time          when true will query the {https://www.ably.com Ably} system for the current time instead of using the local time
       # @option options [Hash]                    :default_token_params   convenience to pass in +token_params+ that will be used as a default for all token requests. See {Auth#create_token_request}
       #
       # @option options [Integer]                 :http_open_timeout       (4 seconds) timeout in seconds for opening an HTTP connection for all HTTP requests


### PR DESCRIPTION
Resolves #353 

Fix URLs in the comments.