### PR TITLE
Fix doc comment: incorrect channel.state type

### DIFF
--- a/lib/ably/realtime/channel.rb
+++ b/lib/ably/realtime/channel.rb
@@ -26,7 +26,7 @@ module Ably
     #   Channel::STATE.Failed
     #
     # @!attribute [r] state
-    #   @return {Ably::Realtime::Connection::STATE} channel state
+    #   @return {Ably::Realtime::Channel::STATE} channel state
     #
     class Channel
       include Ably::Modules::Conversions


### PR DESCRIPTION
Fixed incorrect channel state class from https://github.com/ably/ably-ruby/blob/main/lib/ably/realtime/channel.rb#L29