### PR TITLE
Remove validation of message size for incoming messages

### DIFF
--- a/lib/ably/realtime/client/incoming_message_dispatcher.rb
+++ b/lib/ably/realtime/client/incoming_message_dispatcher.rb
@@ -121,24 +121,16 @@ module Ably::Realtime
             presence.manager.sync_process_messages protocol_message.channel_serial, protocol_message.presence
 
           when ACTION.Presence
-            if protocol_message.has_correct_message_size?
               presence = get_channel(protocol_message.channel).presence
               protocol_message.presence.each do |presence_message|
                 presence.__incoming_msgbus__.publish :presence, presence_message
               end
-            else
-              logger.fatal Ably::Exceptions::ProtocolError.new("Not published. Channel message limit exceeded #{protocol_message.message_size} bytes", 400, Ably::Exceptions::Codes::UNABLE_TO_RECOVER_CHANNEL_MESSAGE_LIMIT_EXCEEDED).message
-            end
 
           when ACTION.Message
-            if protocol_message.has_correct_message_size?
               channel = get_channel(protocol_message.channel)
               protocol_message.messages.each do |message|
                 channel.__incoming_msgbus__.publish :message, message
               end
-            else
-              logger.fatal Ably::Exceptions::ProtocolError.new("Not published. Channel message limit exceeded #{protocol_message.message_size} bytes", 400, Ably::Exceptions::Codes::UNABLE_TO_RECOVER_CHANNEL_MESSAGE_LIMIT_EXCEEDED).message
-            end
 
           when ACTION.Auth
             client.auth.authorize

--- a/spec/unit/realtime/incoming_message_dispatcher_spec.rb
+++ b/spec/unit/realtime/incoming_message_dispatcher_spec.rb
@@ -32,43 +32,5 @@ describe Ably::Realtime::Client::IncomingMessageDispatcher, :api_private do
       expect(subject).to receive_message_chain(:logger, :warn)
       msgbus.publish :protocol_message, Ably::Models::ProtocolMessage.new(:action => :attached, channel: 'unknown')
     end
-
-    context 'TO3l8' do
-      context 'on action presence' do
-        let(:presence) { 101.times.map { { data: 'x' * 655 } } }
-
-        let(:protocol_message) do
-          Ably::Models::ProtocolMessage.new(action: :presence, channel: 'default', presence: presence, connection_serial: 123123123)
-        end
-
-        it 'should raise a protocol error when message size exceeded 65536 bytes' do
-          allow(connection).to receive(:serial).and_return(12312312)
-          allow(subject).to receive(:update_connection_recovery_info)
-          allow(subject).to receive_message_chain(:logger, :debug)
-          allow(subject).to receive_message_chain(:logger, :warn)
-          expect(subject).to receive_message_chain(:logger, :fatal)
-
-          msgbus.publish :protocol_message, protocol_message
-        end
-      end
-
-      context 'on action message' do
-        let(:messages) { 101.times.map { { data: 'x' * 655 } } }
-
-        let(:protocol_message) do
-          Ably::Models::ProtocolMessage.new(action: :message, channel: 'default', messages: messages, connection_serial: 123123123)
-        end
-
-        it 'should raise a protocol error when message size exceeded 65536 bytes' do
-          allow(connection).to receive(:serial).and_return(12312312)
-          allow(subject).to receive(:update_connection_recovery_info)
-          allow(subject).to receive_message_chain(:logger, :debug)
-          allow(subject).to receive_message_chain(:logger, :warn)
-          expect(subject).to receive_message_chain(:logger, :fatal)
-
-          msgbus.publish :protocol_message, protocol_message
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
There's no need to validate the size of messages received by the client - if they violate the account max message size limit they will be rejected by the service before reaching the client.