### PR TITLE
fix: remove inbound message size validation

### DIFF
--- a/lib/ably/models/protocol_message.rb
+++ b/lib/ably/models/protocol_message.rb
@@ -189,10 +189,6 @@ module Ably::Models
       presence.map(&:size).sum + messages.map(&:size).sum
     end
 
-    def has_correct_message_size?
-      message_size <= connection_details.max_message_size
-    end
-
     def params
       @params ||= attributes[:params].to_h
     end

--- a/lib/ably/realtime/client/incoming_message_dispatcher.rb
+++ b/lib/ably/realtime/client/incoming_message_dispatcher.rb
@@ -121,23 +121,15 @@ module Ably::Realtime
             presence.manager.sync_process_messages protocol_message.channel_serial, protocol_message.presence
 
           when ACTION.Presence
-            if protocol_message.has_correct_message_size?
-              presence = get_channel(protocol_message.channel).presence
-              protocol_message.presence.each do |presence_message|
-                presence.__incoming_msgbus__.publish :presence, presence_message
-              end
-            else
-              logger.fatal Ably::Exceptions::ProtocolError.new("Not published. Channel message limit exceeded #{protocol_message.message_size} bytes", 400, Ably::Exceptions::Codes::UNABLE_TO_RECOVER_CHANNEL_MESSAGE_LIMIT_EXCEEDED).message
+            presence = get_channel(protocol_message.channel).presence
+            protocol_message.presence.each do |presence_message|
+              presence.__incoming_msgbus__.publish :presence, presence_message
             end
 
           when ACTION.Message
-            if protocol_message.has_correct_message_size?
-              channel = get_channel(protocol_message.channel)
-              protocol_message.messages.each do |message|
-                channel.__incoming_msgbus__.publish :message, message
-              end
-            else
-              logger.fatal Ably::Exceptions::ProtocolError.new("Not published. Channel message limit exceeded #{protocol_message.message_size} bytes", 400, Ably::Exceptions::Codes::UNABLE_TO_RECOVER_CHANNEL_MESSAGE_LIMIT_EXCEEDED).message
+            channel = get_channel(protocol_message.channel)
+            protocol_message.messages.each do |message|
+              channel.__incoming_msgbus__.publish :message, message
             end
 
           when ACTION.Auth

--- a/spec/unit/models/protocol_message_spec.rb
+++ b/spec/unit/models/protocol_message_spec.rb
@@ -400,32 +400,6 @@ describe Ably::Models::ProtocolMessage do
       end
     end
 
-    context '#has_correct_message_size? (#TO3l8)' do
-      context 'on presence' do
-        it 'should return true when a message has correct size' do
-          protocol_message = new_protocol_message(presence: [{ action: 1, data: 'x' * 100 }])
-          expect(protocol_message.has_correct_message_size?).to eq(true)
-        end
-
-        it 'should return false when a message has not correct size' do
-          protocol_message = new_protocol_message(presence: [{ action: 1, data: 'x' * 65537 }])
-          expect(protocol_message.has_correct_message_size?).to eq(false)
-        end
-      end
-
-      context 'on message' do
-        it 'should return true when a message has correct size' do
-          protocol_message = new_protocol_message(messages: [{ name: 'x' * 100 }])
-          expect(protocol_message.has_correct_message_size?).to eq(true)
-        end
-
-        it 'should return false when a message has not correct size' do
-          protocol_message = new_protocol_message(messages: [{ name: 'x' * 65537 }])
-          expect(protocol_message.has_correct_message_size?).to eq(false)
-        end
-      end
-    end
-
     context '#connection_details (#TR4o)' do
       let(:connection_details) { protocol_message.connection_details }
 

--- a/spec/unit/realtime/incoming_message_dispatcher_spec.rb
+++ b/spec/unit/realtime/incoming_message_dispatcher_spec.rb
@@ -32,43 +32,5 @@ describe Ably::Realtime::Client::IncomingMessageDispatcher, :api_private do
       expect(subject).to receive_message_chain(:logger, :warn)
       msgbus.publish :protocol_message, Ably::Models::ProtocolMessage.new(:action => :attached, channel: 'unknown')
     end
-
-    context 'TO3l8' do
-      context 'on action presence' do
-        let(:presence) { 101.times.map { { data: 'x' * 655 } } }
-
-        let(:protocol_message) do
-          Ably::Models::ProtocolMessage.new(action: :presence, channel: 'default', presence: presence, connection_serial: 123123123)
-        end
-
-        it 'should raise a protocol error when message size exceeded 65536 bytes' do
-          allow(connection).to receive(:serial).and_return(12312312)
-          allow(subject).to receive(:update_connection_recovery_info)
-          allow(subject).to receive_message_chain(:logger, :debug)
-          allow(subject).to receive_message_chain(:logger, :warn)
-          expect(subject).to receive_message_chain(:logger, :fatal)
-
-          msgbus.publish :protocol_message, protocol_message
-        end
-      end
-
-      context 'on action message' do
-        let(:messages) { 101.times.map { { data: 'x' * 655 } } }
-
-        let(:protocol_message) do
-          Ably::Models::ProtocolMessage.new(action: :message, channel: 'default', messages: messages, connection_serial: 123123123)
-        end
-
-        it 'should raise a protocol error when message size exceeded 65536 bytes' do
-          allow(connection).to receive(:serial).and_return(12312312)
-          allow(subject).to receive(:update_connection_recovery_info)
-          allow(subject).to receive_message_chain(:logger, :debug)
-          allow(subject).to receive_message_chain(:logger, :warn)
-          expect(subject).to receive_message_chain(:logger, :fatal)
-
-          msgbus.publish :protocol_message, protocol_message
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
Resolves #377

`TO3l8` specifies the requirement of the SDK to validate message size for outbound messages so the check for inbound messages is not needed. Moreover the existing implementation reads `connection_details` from the `MESSAGE` protocol message (which is always unset) and falls back to the library default, so doesn't work when an account has a configured max_message_size