### PR TITLE
Use the correct release of the test observability action

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,7 +40,7 @@ jobs:
           retention-days: 7
       - name: Upload test results
         if: always()
-        uses: ably-labs/test-observability-action@main
+        uses: ably/test-observability-action@v1
         with:
           server-url: 'https://test-observability.herokuapp.com'
           server-auth: ${{ secrets.TEST_OBSERVABILITY_SERVER_AUTH_KEY }}


### PR DESCRIPTION
I noticed that this repository was still using the archived and obsoleted instance of this action from the `ably-labs` org.