### PR TITLE
[ECO-4767] Fix server certificate validation for HTTP in Realtime

### DIFF
--- a/ably.gemspec
+++ b/ably.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'eventmachine', '~> 1.2.6'
-  spec.add_runtime_dependency 'em-http-request', '~> 1.1'
+  spec.add_runtime_dependency 'ably-em-http-request', '~> 1.1.8'
   spec.add_runtime_dependency 'statesman', '~> 9.0'
   spec.add_runtime_dependency 'faraday', '~> 2.2'
   spec.add_runtime_dependency 'faraday-typhoeus', '~> 0.2.0'

--- a/lib/ably/realtime/connection.rb
+++ b/lib/ably/realtime/connection.rb
@@ -327,7 +327,7 @@ module Ably
       def internet_up?
         url = "http#{'s' if client.use_tls?}:#{Ably::INTERNET_CHECK.fetch(:url)}"
         EventMachine::DefaultDeferrable.new.tap do |deferrable|
-          EventMachine::HttpRequest.new(url, tls: { verify_peer: true }).get.tap do |http|
+          EventMachine::AblyHttpRequest::HttpRequest.new(url, tls: { verify_peer: true }).get.tap do |http|
             http.errback do
               yield false if block_given?
               deferrable.fail Ably::Exceptions::ConnectionFailed.new("Unable to connect to #{url}", nil, Ably::Exceptions::Codes::CONNECTION_FAILED)

--- a/spec/acceptance/realtime/connection_spec.rb
+++ b/spec/acceptance/realtime/connection_spec.rb
@@ -1702,13 +1702,13 @@ describe Ably::Realtime::Connection, :event_machine do
         end
 
         context 'internet up URL protocol' do
-          let(:http_request) { double('EventMachine::HttpRequest', get: EventMachine::DefaultDeferrable.new) }
+          let(:http_request) { double('EventMachine::AblyHttpRequest::HttpRequest', get: EventMachine::DefaultDeferrable.new) }
 
           context 'when using TLS for the connection' do
             let(:client_options) { default_options.merge(tls: true) }
 
             it 'uses TLS for the Internet check to https://internet-up.ably-realtime.com/is-the-internet-up.txt' do
-              expect(EventMachine::HttpRequest).to receive(:new).with('https://internet-up.ably-realtime.com/is-the-internet-up.txt', { tls: { verify_peer: true } }).and_return(http_request)
+              expect(EventMachine::AblyHttpRequest::HttpRequest).to receive(:new).with('https://internet-up.ably-realtime.com/is-the-internet-up.txt', { tls: { verify_peer: true } }).and_return(http_request)
               connection.internet_up?
               stop_reactor
             end
@@ -1718,7 +1718,7 @@ describe Ably::Realtime::Connection, :event_machine do
             let(:client_options) { default_options.merge(tls: false, use_token_auth: true) }
 
             it 'uses TLS for the Internet check to http://internet-up.ably-realtime.com/is-the-internet-up.txt' do
-              expect(EventMachine::HttpRequest).to receive(:new).with('http://internet-up.ably-realtime.com/is-the-internet-up.txt', { tls: { verify_peer: true } }).and_return(http_request)
+              expect(EventMachine::AblyHttpRequest::HttpRequest).to receive(:new).with('http://internet-up.ably-realtime.com/is-the-internet-up.txt', { tls: { verify_peer: true } }).and_return(http_request)
               connection.internet_up?
               stop_reactor
             end
@@ -1732,7 +1732,7 @@ describe Ably::Realtime::Connection, :event_machine do
             let(:client_options) { default_options.merge(tls: true) }
 
             it 'checks the Internet up URL over TLS' do
-              expect(EventMachine::HttpRequest).to receive(:new).with("https:#{Ably::INTERNET_CHECK.fetch(:url)}", { tls: { verify_peer: true } }).and_return(double('request', get: EventMachine::DefaultDeferrable.new))
+              expect(EventMachine::AblyHttpRequest::HttpRequest).to receive(:new).with("https:#{Ably::INTERNET_CHECK.fetch(:url)}", { tls: { verify_peer: true } }).and_return(double('request', get: EventMachine::DefaultDeferrable.new))
               connection.internet_up?
               stop_reactor
             end
@@ -1742,7 +1742,7 @@ describe Ably::Realtime::Connection, :event_machine do
             let(:client_options) { default_options.merge(tls: false, use_token_auth: true) }
 
             it 'checks the Internet up URL over TLS' do
-              expect(EventMachine::HttpRequest).to receive(:new).with("http:#{Ably::INTERNET_CHECK.fetch(:url)}", { tls: { verify_peer: true } }).and_return(double('request', get: EventMachine::DefaultDeferrable.new))
+              expect(EventMachine::AblyHttpRequest::HttpRequest).to receive(:new).with("http:#{Ably::INTERNET_CHECK.fetch(:url)}", { tls: { verify_peer: true } }).and_return(double('request', get: EventMachine::DefaultDeferrable.new))
               connection.internet_up?
               stop_reactor
             end


### PR DESCRIPTION
Resolves #396.

(The tests pass when combined with @sacOO7’s WIP test fixes from #391; see #403.)