### PR TITLE
Turn off `continue-on-error` in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,8 +7,8 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         ruby: [ '2.7', '3.0', '3.1' ]
         protocol: [ 'json', 'msgpack' ]


### PR DESCRIPTION
We want the workflow run to fail if any of the jobs fails.

The motivation for the current configuration is not clear to me, but I’m guessing the idea was that the failure of a single job shouldn’t cancel the others. Turning off fail-fast should do the same thing.

(Copied from ably-js commit ddef9f7.)