### PR TITLE
rest/channel_spec: fix test checking error messages

### DIFF
--- a/spec/acceptance/rest/channel_spec.rb
+++ b/spec/acceptance/rest/channel_spec.rb
@@ -280,7 +280,7 @@ describe Ably::Rest::Channel do
 
             context 'with an invalid client_id in the message' do
               it 'succeeds in the client library but then fails when published to Ably' do
-                expect { channel.publish([name: 'event', client_id: 'invalid']) }.to raise_error Ably::Exceptions::InvalidRequest, /40012/
+                expect { channel.publish([name: 'event', client_id: 'invalid']) }.to raise_error(Ably::Exceptions::InvalidRequest, /40012/)
               end
             end
 

--- a/spec/acceptance/rest/channel_spec.rb
+++ b/spec/acceptance/rest/channel_spec.rb
@@ -191,7 +191,7 @@ describe Ably::Rest::Channel do
         let(:client_options) { default_options.merge(use_token_auth: true, default_token_params: { capability: capability }) }
 
         it 'raises a permission error when publishing' do
-          expect { channel.publish(name, data) }.to raise_error(Ably::Exceptions::UnauthorizedRequest, /not permitted/)
+          expect { channel.publish(name, data) }.to raise_error(Ably::Exceptions::UnauthorizedRequest, /40160/)
         end
       end
 
@@ -280,7 +280,7 @@ describe Ably::Rest::Channel do
 
             context 'with an invalid client_id in the message' do
               it 'succeeds in the client library but then fails when published to Ably' do
-                expect { channel.publish([name: 'event', client_id: 'invalid']) }.to raise_error Ably::Exceptions::InvalidRequest, /mismatched clientId/
+                expect { channel.publish([name: 'event', client_id: 'invalid']) }.to raise_error Ably::Exceptions::InvalidRequest, /40012/
               end
             end
 


### PR DESCRIPTION
Replace error message checks with error code checks. Error messages are not guaranteed to be consistent across versions/systems but the error codes are.