### PR TITLE
Fix lamda used in channel detach

### DIFF
--- a/lib/ably/realtime/channel/channel_manager.rb
+++ b/lib/ably/realtime/channel/channel_manager.rb
@@ -243,10 +243,10 @@ module Ably::Realtime
           end
         end
 
-        on_disconnected_and_connected = lambda do
+        on_disconnected_and_connected = lambda do |&block|
           connection.unsafe_once(:disconnected) do
             connection.unsafe_once(:connected) do
-              yield if pending_state_change_timer
+              block.call if pending_state_change_timer
             end if pending_state_change_timer
           end
         end

--- a/spec/acceptance/realtime/channel_spec.rb
+++ b/spec/acceptance/realtime/channel_spec.rb
@@ -830,10 +830,8 @@ describe Ably::Realtime::Channel, :event_machine do
           it 'does the detach operation once the connection state is connected (#RTL5h)' do
             connection.once(:connected) do
               connection.once(:disconnected) do
-                channel.on :attaching do
-                  channel.detach
-                end
                 channel.attach
+                channel.detach
                 connection.once(:connected) do
                   channel.once(:attached) do
                     channel.once(:detached) do


### PR DESCRIPTION
- Fix lamda block supplied as a part of channel detach, since use of yield inside lamda is not allowed.
- Instead block should be passed and called explicitly.
- https://stackoverflow.com/questions/30649742/declaring-a-ruby-lambda-with-a-yield