### PR TITLE
spec: Don't expect integers to round-trip through msg.extras

### DIFF
--- a/spec/acceptance/realtime/message_spec.rb
+++ b/spec/acceptance/realtime/message_spec.rb
@@ -173,7 +173,7 @@ describe 'Ably::Realtime::Channel Message', :event_machine do
       end
 
       context 'JSON Array' do
-        let(:data) { { 'push' => { 'data' => { 'key' => [ true, false, 55, nil, 'string', { 'Hash' => true }, ['array'] ] } } } }
+        let(:data) { { 'push' => { 'data' => { 'key' => [ true, false, 55.1, nil, 'string', { 'Hash' => true }, ['array'] ] } } } }
 
         it 'is encoded and decoded to the same Array' do
           publish_and_check_extras data


### PR DESCRIPTION
Internally, we store msg.extras in a protobuf.Struct which stores a JSON number in a double field:

https://github.com/protocolbuffers/protobuf/blob/5cbf13bc9ab0f883bcb664241f6be8d962915569/src/google/protobuf/struct.proto#L56-L78

This means that when a connection is using binary encoding (i.e. msgpack), any numbers in msg.extras are stored as floats even if the inbound message encoded the number as an int type, so the inbound and outbound representations are not guaranteed to be the same, although the semantic numeric value will be the same.

This commit handles this nuance by not expecting an integer to come back as an integer in msg.extras, but expecting a float to instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Updated test data to ensure type consistency by changing an integer value to a floating-point number, enhancing accuracy in data processing scenarios.
  
- **Tests**
	- Improved test reliability by refining the data structure used in acceptance tests, which may impact validations and assertions involved in encoding and decoding operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->