### PR TITLE
Fix decoding of MessagePack data, and other fixes to CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -46,7 +46,7 @@ jobs:
           server-url: 'https://test-observability.herokuapp.com'
           server-auth: ${{ secrets.TEST_OBSERVABILITY_SERVER_AUTH_KEY }}
           path: 'junit/'
-      - uses: coverallsapp/github-action@1.1.3
+      - uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           flag-name: ruby-${{ matrix.ruby }}-${{ matrix.protocol }}-${{ matrix.type }}
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Coveralls Finished
-        uses: coverallsapp/github-action@1.1.3
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.github_token }}
           parallel-finished: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,8 +32,9 @@ jobs:
         run: |
           mkdir junit
           bundle exec parallel_rspec --prefix-output-with-test-env-number --first-is-1 -- spec/${{ matrix.type }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: test-results-ruby-${{ matrix.ruby }}-${{ matrix.protocol }}-${{ matrix.type }}
           path: |
             junit/
             coverage/

--- a/ably.gemspec
+++ b/ably.gemspec
@@ -25,7 +25,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'faraday-typhoeus', '~> 0.2.0'
   spec.add_runtime_dependency 'typhoeus', '~> 1.4'
   spec.add_runtime_dependency 'json'
-  spec.add_runtime_dependency 'websocket-driver', '~> 0.7'
+  # We disallow minor version updates, because this gem has introduced breaking API changes in minor releases before (which it's within its rights to do, given it's pre-v1). If you want to allow a new minor version, bump here and run the tests.
+  spec.add_runtime_dependency 'websocket-driver', '~> 0.8.0'
   spec.add_runtime_dependency 'msgpack', '>= 1.3.0'
   spec.add_runtime_dependency 'addressable', '>= 2.0.0'
 

--- a/lib/ably/realtime/connection/websocket_transport.rb
+++ b/lib/ably/realtime/connection/websocket_transport.rb
@@ -257,7 +257,7 @@ module Ably::Realtime
         when :json
           JSON.parse(data)
         when :msgpack
-          MessagePack.unpack(data.pack('C*'))
+          MessagePack.unpack(data)
         else
           client.logger.fatal { "WebsocketTransport: Unsupported Protocol Message format #{client.protocol}" }
           data

--- a/spec/acceptance/realtime/client_spec.rb
+++ b/spec/acceptance/realtime/client_spec.rb
@@ -34,7 +34,7 @@ describe Ably::Realtime::Client, :event_machine do
             client.connection.once(:failed) do
               expect(custom_logger_object.logs.find do |severity, message|
                 next unless %w(fatal error).include?(severity.to_s)
-                message.match(%r{https://help.ably.io/error/40400})
+                message.match(%r{https://help.ably.io/error/40101})
               end).to_not be_nil
               stop_reactor
             end

--- a/spec/acceptance/realtime/connection_failures_spec.rb
+++ b/spec/acceptance/realtime/connection_failures_spec.rb
@@ -26,13 +26,13 @@ describe Ably::Realtime::Connection, 'failures', :event_machine do
         context 'with invalid app part of the key' do
           let(:invalid_key) { 'not_an_app.invalid_key_name:invalid_key_value' }
 
-          it 'enters the failed state and returns a not found error' do
+          it 'enters the failed state and returns an invalid credentials error' do
             connection.on(:failed) do |connection_state_change|
               error = connection_state_change.reason
               expect(connection.state).to eq(:failed)
               # TODO: Check error type is an InvalidToken exception
-              expect(error.status).to eq(404)
-              expect(error.code).to eq(40400) # not found
+              expect(error.status).to eq(401)
+              expect(error.code).to eq(40101) # invalid credentials
               stop_reactor
             end
           end
@@ -1396,10 +1396,10 @@ describe Ably::Realtime::Connection, 'failures', :event_machine do
           channel = client.channels.get("foo")
           channel.attach do
             connection.once(:failed) do |state_change|
-              expect(state_change.reason.code).to eql(40400)
-              expect(connection.error_reason.code).to eql(40400)
+              expect(state_change.reason.code).to eql(40101)
+              expect(connection.error_reason.code).to eql(40101)
               expect(channel).to be_failed
-              expect(channel.error_reason.code).to eql(40400)
+              expect(channel.error_reason.code).to eql(40101)
               stop_reactor
             end
 

--- a/spec/acceptance/realtime/connection_failures_spec.rb
+++ b/spec/acceptance/realtime/connection_failures_spec.rb
@@ -46,7 +46,7 @@ describe Ably::Realtime::Connection, 'failures', :event_machine do
               error = connection_state_change.reason
               expect(connection.state).to eq(:failed)
               # TODO: Check error type is a TokenNotFound exception
-              expect(error.status).to eq(401)
+              expect(error.status).to eq(404)
               expect(error.code).to eq(40400) # not found
               stop_reactor
             end

--- a/spec/acceptance/rest/base_spec.rb
+++ b/spec/acceptance/rest/base_spec.rb
@@ -72,13 +72,12 @@ describe Ably::Rest do
 
     describe 'failed requests' do
       context 'due to invalid Auth' do
-        it 'should raise an InvalidRequest exception with a valid error message and code' do
+        it 'should raise an UnauthorizedRequest exception with a valid error message and code' do
           invalid_client = Ably::Rest::Client.new(key: 'appid.keyuid:keysecret', environment: environment)
           expect { invalid_client.channel('test').publish('foo', 'choo') }.to raise_error do |error|
-            expect(error).to be_a(Ably::Exceptions::ResourceMissing)
-            expect(error.message).to match(/No application found/)
-            expect(error.code).to eql(40400)
-            expect(error.status).to eql(404)
+            expect(error).to be_a(Ably::Exceptions::UnauthorizedRequest)
+            expect(error.code).to eql(40101)
+            expect(error.status).to eql(401)
           end
         end
       end

--- a/spec/acceptance/rest/client_spec.rb
+++ b/spec/acceptance/rest/client_spec.rb
@@ -33,9 +33,9 @@ describe Ably::Rest::Client do
         it 'logs an entry with a help href url matching the code #TI5' do
           begin
             client.channels.get('foo').publish('test')
-            raise 'Expected Ably::Exceptions::ResourceMissing'
-          rescue Ably::Exceptions::ResourceMissing => err
-            expect err.to_s.match(%r{https://help.ably.io/error/40400})
+            raise 'Expected Ably::Exceptions::UnauthorizedRequest'
+          rescue Ably::Exceptions::UnauthorizedRequest => err
+            expect err.to_s.match(%r{https://help.ably.io/error/40101})
           end
         end
       end


### PR DESCRIPTION
This fixes:

- an issue with decoding MessagePack data due to a breaking change in the `websocket-driver` gem (we should do a release for this because it may be affecting customers)
- a partial fix for #444, to prevent token errors from triggering the use of a fallback host for realtime connections, which fixes an intermittent test failure
- a test that was failing because of backend changes
- a couple of other things that were causing issues in CI

See commit messages for more details.