### PR TITLE
ci: GHA workflow security cleanup

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,11 +19,11 @@ jobs:
         protocol: [ 'json', 'msgpack' ]
         type: [ 'unit', 'acceptance' ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           submodules: 'recursive'
           persist-credentials: false
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
@@ -37,7 +37,7 @@ jobs:
         run: |
           mkdir junit
           bundle exec parallel_rspec --prefix-output-with-test-env-number --first-is-1 -- "spec/$TEST_TYPE"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: test-results-ruby-${{ matrix.ruby }}-${{ matrix.protocol }}-${{ matrix.type }}
           path: |
@@ -46,12 +46,12 @@ jobs:
           retention-days: 7
       - name: Upload test results
         if: always()
-        uses: ably/test-observability-action@v1
+        uses: ably/test-observability-action@5b61d9c59f356b83426cab1b8243dd8bf03c1bea # v1
         with:
           server-url: 'https://test-observability.herokuapp.com'
           server-auth: ${{ secrets.TEST_OBSERVABILITY_SERVER_AUTH_KEY }}
           path: 'junit/'
-      - uses: coverallsapp/github-action@v2
+      - uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           flag-name: ruby-${{ matrix.ruby }}-${{ matrix.protocol }}-${{ matrix.type }}
@@ -63,7 +63,7 @@ jobs:
       contents: read
     steps:
       - name: Coveralls Finished
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2
         with:
           github-token: ${{ secrets.github_token }}
           parallel-finished: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
+          persist-credentials: false
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,9 +5,13 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -55,6 +59,8 @@ jobs:
   finish:
     needs: check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@v2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,7 +36,7 @@ jobs:
           RUBY_VERSION: ${{ matrix.ruby }}
         run: |
           mkdir junit
-          bundle exec parallel_rspec --prefix-output-with-test-env-number --first-is-1 -- spec/${{ matrix.type }}
+          bundle exec parallel_rspec --prefix-output-with-test-env-number --first-is-1 -- "spec/$TEST_TYPE"
       - uses: actions/upload-artifact@v4
         with:
           name: test-results-ruby-${{ matrix.ruby }}-${{ matrix.protocol }}-${{ matrix.type }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,11 +10,11 @@ jobs:
       deployments: write
       id-token: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           persist-credentials: false
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           ruby-version: '2.7'
           bundler-cache: true
@@ -24,14 +24,14 @@ jobs:
           bundle exec yard --readme INTRO.md --tag "spec:Specification"
           ls -al doc/
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1
         with:
           aws-region: eu-west-2
           role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-ably-ruby
           role-session-name: "${{ github.run_id }}-${{ github.run_number }}"
 
       - name: Upload Documentation
-        uses: ably/sdk-upload-action@v1
+        uses: ably/sdk-upload-action@8c6179796fc7ee8fc9bb28d5223ffef005b985cc # v1
         with:
           sourcePath: doc/
           githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -6,8 +6,14 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   build:
+    permissions:
+      contents: read
+      deployments: write
+      id-token: write
     uses: ably/features/.github/workflows/sdk-features.yml@main
     with:
       repository-name: ably-ruby

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -17,4 +17,5 @@ jobs:
     uses: ably/features/.github/workflows/sdk-features.yml@6b3fc7a8ede2ebdd7a6325314f3a96c6466f1453 # main
     with:
       repository-name: ably-ruby
-    secrets: inherit
+    secrets:
+      ABLY_AWS_ACCOUNT_ID_SDK: ${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
       deployments: write
       id-token: write
-    uses: ably/features/.github/workflows/sdk-features.yml@main
+    uses: ably/features/.github/workflows/sdk-features.yml@6b3fc7a8ede2ebdd7a6325314f3a96c6466f1453 # main
     with:
       repository-name: ably-ruby
     secrets: inherit


### PR DESCRIPTION
Routine hygiene pass over the GitHub Actions workflows in this repo, addressing findings from a workflow security audit. Changes are split into five commits, one per finding type:
- Disable credential persistence on actions/checkout steps so the workflow's GITHUB_TOKEN is not left in the local git config after checkout.
- Scope each job's permissions explicitly: top-level permissions: {}, with each job granted only the GITHUB_TOKEN scopes it actually needs.
- Move the workflow-context expansion (${{ matrix.type }}) out of run: shell source and read it from the already-defined TEST_TYPE env binding instead.
- Pin all third-party actions to commit SHAs (with the tag preserved as a comment) so an upstream tag move can't silently change what runs in CI.
- Replace secrets: inherit on the reusable ably/features workflow call with an explicit passthrough of the single secret it declares (ABLY_AWS_ACCOUNT_ID_SDK), so unrelated repo secrets aren't forwarded into it.

No behavioural changes intended — the workflows run the same checks against the same inputs.